### PR TITLE
docs: removed comment in the getting started and dynamically show section navigation to give main content more space

### DIFF
--- a/docs/source/_static/api-detection.js
+++ b/docs/source/_static/api-detection.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', function() {
+    if (typeof DOCUMENTATION_OPTIONS !== 'undefined' && DOCUMENTATION_OPTIONS.pagename) {
+        const pagename = DOCUMENTATION_OPTIONS.pagename;
+        if (pagename === 'modules' || pagename.startsWith('think_reason_learn')) {
+            document.body.setAttribute('data-api-page', 'true');
+        }
+    }
+});

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -33,3 +33,29 @@ a.navbar-brand img {
     width: auto !important;
     margin: 0 auto;
 }
+
+.bd-sidebar-primary {
+    display: none !important;
+}
+
+body[data-api-page="true"] .bd-sidebar-primary {
+    display: block !important;
+}
+
+.bd-main .bd-content {
+    max-width: 100% !important;
+    margin-left: 0 !important;
+}
+
+body[data-api-page="true"] .bd-main .bd-content {
+    max-width: unset !important;
+    margin-left: unset !important;
+}
+
+.bd-container {
+    grid-template-columns: 0 1fr 0 !important;
+}
+
+body[data-api-page="true"] .bd-container {
+    grid-template-columns: var(--bd-sidebar-width) 1fr var(--bd-sidebar-width) !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,6 +126,7 @@ html_css_files = ["custom.css"]
 # Custom JavaScript to make external links open in new tabs
 html_js_files = [
     "external_links.js",
+    "api-detection.js",
 ]
 html_title = "Think Reason Learn"
 html_short_title = "TRL"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,6 @@ venture capital, healthcare, and law.
    :gutter: 3
 
    .. grid-item-card:: Getting Started
-      # No :columns: — auto full on small, half on medium/large
 
       - :doc:`About <getting_started/about>`
       - :doc:`Installation Guide <getting_started/installation_guide>`


### PR DESCRIPTION
## Summary
Removed comment line from getting started  title on home

Remove section navigation sidebar since it doesn't do much unless it gets to the api reference and expanded main content area

Added js to only show the section navigation only on the api reference page

## Type of change
- [ ] feat
- [ ] fix
- [ ] refactor
- [x] docs
- [ ] test
- [ ] chore

## Checklist
- [ ] Tests added/updated
- [x] Lint and type-check pass
- [ ] Docs updated (if needed)

## Related issues
Closes #
