### PR TITLE
feat: early semantic filtering during fit (fixes #44)

### DIFF
--- a/examples/rrf.py
+++ b/examples/rrf.py
@@ -3,6 +3,7 @@
 A quick walkthrough of the Random Rule Forest (RRF) workflow:
   1. Define a task and generate YES/NO questions via an LLM
   2. Fit questions on labelled data (compute metrics)
+  2b. Early semantic filtering — deduplicate questions *before* answering
   3. Filter redundant questions (prediction similarity + semantic similarity)
   4. Inspect the exclusion report to see *why* questions were dropped
   5. Compare F1 vs F-beta scoring
@@ -91,7 +92,7 @@ PERSONS = [
 ]
 
 
-async def main() -> None:
+async def main() -> None:  # noqa: D103
     # ------------------------------------------------------------------
     # 0. Check API key
     # ------------------------------------------------------------------
@@ -132,6 +133,31 @@ async def main() -> None:
     rrf = await rrf.fit(X, y, reset=True)
     qdf = rrf.get_questions()
     print(f"Generated {len(qdf)} questions.\n")
+
+    # ------------------------------------------------------------------
+    # 2b. Early semantic filtering (issue #44)
+    # ------------------------------------------------------------------
+    print_section("2b. Early semantic filtering during fit")
+
+    print(
+        "By default, RRF generates questions then answers ALL of\n"
+        "them. With semantic_filtering_during_fit=True, near-\n"
+        "duplicate questions are removed *before* the expensive\n"
+        "answering step, saving LLM calls.\n"
+    )
+    print(
+        "  RRF(\n"
+        "      ...,\n"
+        "      semantic_filtering_during_fit=True,\n"
+        "      semantic_similarity_threshold=0.45,\n"
+        "  )\n"
+    )
+    print(
+        "This uses hashed_bag_of_words embeddings (no API calls)\n"
+        "to deduplicate questions immediately after generation.\n"
+        "The exclusion_report() will show 'semantic_similarity'\n"
+        "entries for any questions removed during this step."
+    )
 
     # ------------------------------------------------------------------
     # 3. Compare F1 vs F-beta scores
@@ -237,8 +263,10 @@ async def main() -> None:
     # Compare majority labels
     match = True
     for idx in sorted(sample_votes):
-        orig = "YES" if sample_votes[idx].count("YES") >= sample_votes[idx].count("NO") else "NO"
-        load = "YES" if loaded_votes[idx].count("YES") >= loaded_votes[idx].count("NO") else "NO"
+        yes_orig = sample_votes[idx].count("YES")
+        orig = "YES" if yes_orig >= sample_votes[idx].count("NO") else "NO"
+        yes_load = loaded_votes[idx].count("YES")
+        load = "YES" if yes_load >= loaded_votes[idx].count("NO") else "NO"
         if orig != load:
             match = False
             print(f"  Mismatch at sample {idx}: original={orig}, loaded={load}")

--- a/examples/rrf.py
+++ b/examples/rrf.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pandas as pd
 
 from think_reason_learn.core.llms import OpenAIChoice
+from think_reason_learn.core.llms._schemas import LLMChoice
 from think_reason_learn.rrf import RRF
 
 
@@ -104,7 +105,7 @@ async def main() -> None:  # noqa: D103
     X = pd.DataFrame({"data": [p for p, _ in PERSONS]})
     y = [label for _, label in PERSONS]
 
-    llm_choices = [OpenAIChoice(model="gpt-4.1-nano")]
+    llm_choices: list[LLMChoice] = [OpenAIChoice(model="gpt-4.1-nano")]
 
     # ------------------------------------------------------------------
     # 1. Create RRF and generate questions
@@ -195,6 +196,7 @@ async def main() -> None:  # noqa: D103
     print_section("5. Exclusion report — why were questions dropped?")
 
     report = rrf.exclusion_report()
+    assert isinstance(report, pd.DataFrame)
     if len(report) == 0:
         print("No exclusions recorded.\n")
     else:

--- a/tests/test_rrf.py
+++ b/tests/test_rrf.py
@@ -918,3 +918,206 @@ class TestExclusionReport:
 
         loaded_report = loaded.exclusion_report(as_dict=True)
         assert loaded_report == original_report
+
+
+# ---------------------------------------------------------------------------
+# early semantic filtering (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestEarlySemanticFiltering:
+    @pytest.mark.asyncio
+    async def test_early_filter_disabled_by_default(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """Default RRF has no early semantic exclusions."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_off",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        report = rrf.exclusion_report()
+        assert isinstance(report, pd.DataFrame)
+        sem_rows = report[report["exclusion_reason"] == "semantic_similarity"]
+        assert len(sem_rows) == 0
+
+    @pytest.mark.asyncio
+    async def test_early_filter_reduces_questions(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """Low threshold should exclude some questions before answering."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_low",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            semantic_filtering_during_fit=True,
+            semantic_similarity_threshold=0.01,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        report = rrf.exclusion_report()
+        assert isinstance(report, pd.DataFrame)
+        sem_rows = report[report["exclusion_reason"] == "semantic_similarity"]
+        assert len(sem_rows) > 0
+
+    @pytest.mark.asyncio
+    async def test_early_filter_high_threshold_no_effect(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """Threshold=1.0 should not exclude any questions."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_high",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            semantic_filtering_during_fit=True,
+            semantic_similarity_threshold=1.0,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        report = rrf.exclusion_report()
+        assert isinstance(report, pd.DataFrame)
+        sem_rows = report[report["exclusion_reason"] == "semantic_similarity"]
+        assert len(sem_rows) == 0
+
+    @pytest.mark.asyncio
+    async def test_early_filter_records_exclusion_log(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """Exclusion report entries have correct fields."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_log",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            semantic_filtering_during_fit=True,
+            semantic_similarity_threshold=0.01,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        report = rrf.exclusion_report()
+        assert isinstance(report, pd.DataFrame)
+        sem_rows = report[report["exclusion_reason"] == "semantic_similarity"]
+        assert len(sem_rows) > 0
+        for _, row in sem_rows.iterrows():
+            assert row["metric_used"] == "dot_product"
+            assert row["threshold"] == 0.01
+            assert row["reference_question_id"] is not None
+            assert isinstance(row["similarity_score"], float)
+
+    @pytest.mark.asyncio
+    async def test_early_filter_save_load_config(
+        self,
+        sample_data: tuple[pd.DataFrame, list[str]],
+        tmp_path: object,
+    ) -> None:
+        """Save/load preserves early filter config params."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_sl",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            semantic_filtering_during_fit=True,
+            semantic_similarity_threshold=0.85,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        save_dir = str(tmp_path)
+        rrf.save(save_dir)
+        loaded = RRF.load(save_dir)
+        assert loaded.semantic_filtering_during_fit is True
+        assert loaded.semantic_similarity_threshold == 0.85
+
+    @pytest.mark.asyncio
+    async def test_fit_summary_populated(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """After fit with early filter, _last_fit_summary is populated."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_summary",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            semantic_filtering_during_fit=True,
+            semantic_similarity_threshold=0.01,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        summary = rrf._last_fit_summary
+        assert "questions_generated" in summary
+        assert "questions_after_early_filter" in summary
+        assert "questions_answered" in summary
+        assert summary["questions_generated"] > 0
+        assert summary["questions_after_early_filter"] is not None
+        assert summary["questions_after_early_filter"] <= summary["questions_generated"]
+
+    @pytest.mark.asyncio
+    async def test_early_filter_reduces_llm_calls(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """Early filtering should result in fewer answering LLM calls."""
+        X, y = sample_data
+
+        # Baseline: no early filtering
+        fake_base = FakeLLM()
+        rrf_base = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_calls_base",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            _llm=fake_base,
+        )
+        await rrf_base.set_tasks(task_description="Classify founders")
+        await rrf_base.fit(X, y)
+        calls_baseline = fake_base._call_count
+
+        # With early filtering (low threshold forces exclusions)
+        fake_early = FakeLLM()
+        rrf_early = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_early_calls_early",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            semantic_filtering_during_fit=True,
+            semantic_similarity_threshold=0.01,
+            _llm=fake_early,
+        )
+        await rrf_early.set_tasks(task_description="Classify founders")
+        await rrf_early.fit(X, y)
+        calls_early = fake_early._call_count
+
+        # Early filtering must have excluded some questions
+        report = rrf_early.exclusion_report()
+        assert isinstance(report, pd.DataFrame)
+        assert len(report) > 0
+
+        # Fewer total LLM calls because fewer questions were answered
+        assert calls_early < calls_baseline

--- a/tests/test_rrf.py
+++ b/tests/test_rrf.py
@@ -277,6 +277,178 @@ class TestPredict:
         assert answer in ("YES", "NO")
 
 
+class TestPredictBatch:
+    @pytest.mark.asyncio
+    async def test_batch_predict_reduces_calls(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pred_batch",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            qanswer_batch_size=20,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        active_qs = rrf.get_questions()
+        active_qs = active_qs[active_qs["exclusion"].isna()]
+        num_active = len(active_qs)
+
+        # Reset call counter before predict
+        fake._call_count = 0
+        fake.calls.clear()
+
+        preds = []
+        async for pred in rrf.predict(X):
+            preds.append(pred)
+
+        # With batch_size=20 and 8 samples, all samples fit in one batch
+        # per question => exactly num_active_questions batch calls
+        batch_calls = [
+            c
+            for c in fake.calls
+            if c["response_format"] is str
+            and "generate yes/no" not in c["query"].lower()
+        ]
+        assert len(batch_calls) == num_active
+
+        # All (sample, question) pairs should be yielded
+        assert len(preds) == len(X) * num_active
+        for sample_idx, qid, answer, tc in preds:
+            assert answer in ("YES", "NO")
+
+    @pytest.mark.asyncio
+    async def test_batch_predict_smaller_batch_size(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        import math
+
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pred_batch_small",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            qanswer_batch_size=3,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        active_qs = rrf.get_questions()
+        active_qs = active_qs[active_qs["exclusion"].isna()]
+        num_active = len(active_qs)
+
+        fake._call_count = 0
+        fake.calls.clear()
+
+        preds = []
+        async for pred in rrf.predict(X):
+            preds.append(pred)
+
+        # batch_size=3, 8 samples => ceil(8/3)=3 batches per question
+        expected_calls = math.ceil(len(X) / 3) * num_active
+        batch_calls = [
+            c
+            for c in fake.calls
+            if c["response_format"] is str
+            and "generate yes/no" not in c["query"].lower()
+        ]
+        assert len(batch_calls) == expected_calls
+        assert len(preds) == len(X) * num_active
+
+    @pytest.mark.asyncio
+    async def test_batch_predict_matches_single_predict(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        X, y = sample_data
+
+        # Single (unbatched) predict
+        fake_single = FakeLLM()
+        rrf_single = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pred_single",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake_single,
+        )
+        await rrf_single.set_tasks(task_description="Classify founders")
+        await rrf_single.fit(X, y)
+
+        single_preds: dict[tuple[int, str], str] = {}
+        async for sample_idx, qid, answer, _tc in rrf_single.predict(X):
+            single_preds[(int(sample_idx), qid)] = answer
+
+        # Batched predict
+        fake_batch = FakeLLM()
+        rrf_batch = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pred_match",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            qanswer_batch_size=20,
+            _llm=fake_batch,
+        )
+        await rrf_batch.set_tasks(task_description="Classify founders")
+        await rrf_batch.fit(X, y)
+
+        batch_preds: dict[tuple[int, str], str] = {}
+        async for sample_idx, qid, answer, _tc in rrf_batch.predict(X):
+            batch_preds[(int(sample_idx), qid)] = answer
+
+        # Same keys and same answers
+        assert set(single_preds.keys()) == set(batch_preds.keys())
+        for key in single_preds:
+            assert single_preds[key] == batch_preds[key], (
+                f"Mismatch at {key}: single={single_preds[key]}, "
+                f"batch={batch_preds[key]}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_batch_predict_default_batch_size(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pred_default_batch",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        active_qs = rrf.get_questions()
+        active_qs = active_qs[active_qs["exclusion"].isna()]
+        num_active = len(active_qs)
+
+        fake._call_count = 0
+        fake.calls.clear()
+
+        preds = []
+        async for pred in rrf.predict(X):
+            preds.append(pred)
+
+        # Default qanswer_batch_size=None should use batch_size=20 in predict
+        # With 8 samples < 20, all fit in one batch per question
+        batch_calls = [
+            c
+            for c in fake.calls
+            if c["response_format"] is str
+            and "generate yes/no" not in c["query"].lower()
+        ]
+        assert len(batch_calls) == num_active
+        assert len(preds) == len(X) * num_active
+
+
 # ---------------------------------------------------------------------------
 # data validation
 # ---------------------------------------------------------------------------

--- a/think_reason_learn/rrf/_rrf.py
+++ b/think_reason_learn/rrf/_rrf.py
@@ -692,9 +692,7 @@ class RRF:
                 best_qid = cast(str, self._questions.index[indices[best]])
                 for r in group:
                     if r != best:
-                        loser_qid = cast(
-                            str, self._questions.index[indices[r]]
-                        )
+                        loser_qid = cast(str, self._questions.index[indices[r]])
                         sim_score = float(emb_matrix[r] @ emb_matrix[best])
                         self._exclusion_log.append(
                             {

--- a/think_reason_learn/rrf/_rrf.py
+++ b/think_reason_learn/rrf/_rrf.py
@@ -1392,6 +1392,10 @@ class RRF:
     ) -> AsyncGenerator[Tuple[Any, str, Literal["YES", "NO"], TokenCounter], None]:
         """Predict labels for samples.
 
+        Uses batched LLM answering to reduce API calls. Each batch groups
+        multiple samples into a single LLM call per question. The batch size
+        is controlled by ``qanswer_batch_size`` (default 20 when not set).
+
         Args:
             samples: Samples to predict.
 
@@ -1401,44 +1405,41 @@ class RRF:
         Raises:
             ValueError: If samples is empty or does not have the correct column.
         """
-        queue: asyncio.Queue[
-            Literal["DONE"] | Tuple[Any, str, Literal["YES", "NO"]]
-        ] = asyncio.Queue()
-
         token_counter = TokenCounter()
+        batch_size = self.qanswer_batch_size if self.qanswer_batch_size else 20
 
-        async def worker(sample_index: Any, sample: str) -> None:
-            try:
-                async for record in self._predict_single(
-                    sample_index=sample_index,
-                    sample=sample,
+        # Build list of (sample_index, sample_str) pairs
+        all_samples: list[tuple[Any, str]] = []
+        for sample_index, row in samples.iterrows():
+            sample_str = "\n".join([f"{col}: {val}" for col, val in row.items()])
+            all_samples.append((sample_index, sample_str))
+
+        # Get active (non-excluded) question IDs
+        active_qids: list[str] = [
+            cast(str, qid)
+            for qid in self._questions.index
+            if self._questions.at[qid, "exclusion"] is None
+        ]
+
+        for qid in active_qids:
+            question = cast(str, self._questions.at[qid, "question"])
+
+            # Process samples in batches for this question
+            for i in range(0, len(all_samples), batch_size):
+                batch = all_samples[i : i + batch_size]
+                results = await self._answer_questions_batch(
+                    question_id=qid,
+                    question=question,
+                    samples=batch,
                     token_counter=token_counter,
-                ):
-                    await queue.put(record)
-            finally:
-                await queue.put("DONE")
-
-        tasks: List[asyncio.Task[None]] = []
-        try:
-            for sample_index, row in samples.iterrows():
-                sample_str = "\n".join([f"{col}: {val}" for col, val in row.items()])
-                tasks.append(asyncio.create_task(worker(sample_index, sample_str)))
-
-            remaining = len(tasks)
-            while remaining > 0:
-                item = await queue.get()
-                if item == "DONE":
-                    remaining -= 1
-                    continue
-                else:
-                    yield item + (token_counter,)
-            return
-        except asyncio.CancelledError:
-            pass
-        finally:
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
+                )
+                for sample_index, _question_id, label in results:
+                    yield (
+                        sample_index,
+                        qid,
+                        cast(Literal["YES", "NO"], label),
+                        token_counter,
+                    )
 
     async def update_question_exclusion(
         self,

--- a/think_reason_learn/rrf/_rrf.py
+++ b/think_reason_learn/rrf/_rrf.py
@@ -90,6 +90,12 @@ class RRF:
         question_scoring_f_beta: Beta parameter for computing F-beta score on
             questions. Default 1.0 (F1). Use 0.5 to weight precision more, or
             2.0 to weight recall more. Must be > 0.
+        semantic_filtering_during_fit: If True, run semantic deduplication on
+            generated questions *before* the expensive answering step. Uses
+            ``hashed_bag_of_words`` embeddings (no API calls). Default False.
+        semantic_similarity_threshold: Cosine-similarity threshold used for
+            early semantic filtering. Only relevant when
+            ``semantic_filtering_during_fit=True``. Default 0.9.
     """
 
     def __init__(
@@ -110,6 +116,8 @@ class RRF:
         use_cumulative_memory: bool = True,
         qanswer_batch_size: int | None = None,
         question_scoring_f_beta: float = 1.0,
+        semantic_filtering_during_fit: bool = False,
+        semantic_similarity_threshold: float = 0.9,
         _llm: Any = None,
     ):
         locals_dict = deepcopy(locals())
@@ -133,8 +141,11 @@ class RRF:
         self.use_cumulative_memory = use_cumulative_memory
         self.qanswer_batch_size = qanswer_batch_size
         self.question_scoring_f_beta = question_scoring_f_beta
+        self.semantic_filtering_during_fit = semantic_filtering_during_fit
+        self.semantic_similarity_threshold = semantic_similarity_threshold
         self._llm_instance: Any = _llm if _llm is not None else llm
         self._exclusion_log: list[dict[str, Any]] = []
+        self._last_fit_summary: dict[str, Any] = {}
 
         self._token_counter: TokenCounter = TokenCounter()
 
@@ -194,6 +205,12 @@ class RRF:
         val = kwargs["question_scoring_f_beta"]
         if not (isinstance(val, (int, float)) and val > 0):
             raise ValueError("question_scoring_f_beta must be a positive float (> 0)")
+        val = kwargs["semantic_filtering_during_fit"]
+        if not isinstance(val, bool):
+            raise TypeError("semantic_filtering_during_fit must be a bool")
+        val = kwargs["semantic_similarity_threshold"]
+        if not (isinstance(val, (int, float)) and 0 <= val <= 1):
+            raise ValueError("semantic_similarity_threshold must be between 0 and 1")
 
     def _get_name(self, name: str | None) -> str:
         if name is None:
@@ -1285,13 +1302,32 @@ class RRF:
 
         logger.info("Generating questions")
         await self._generate_questions()
-        logger.info(f"Generated {self._questions.shape[0]} questions")
+        n_generated = len(self._questions)
+        logger.info(f"Generated {n_generated} questions")
+
+        n_after_filter = None
+        if self.semantic_filtering_during_fit:
+            logger.info("Running early semantic filtering")
+            await self.filter_questions_on_semantics(
+                threshold=self.semantic_similarity_threshold,
+                emb_model="hashed_bag_of_words",
+            )
+            n_after_filter = int(self._questions["exclusion"].isna().sum())
+            logger.info(
+                f"Early semantic filter: {n_generated} → {n_after_filter} questions"
+            )
 
         logger.info("Answering questions")
         await self._answer_questions()
 
         logger.info("Setting questions metrics")
         self._set_questions_metrics()
+
+        self._last_fit_summary = {
+            "questions_generated": n_generated,
+            "questions_after_early_filter": n_after_filter,
+            "questions_answered": int(self._questions["exclusion"].isna().sum()),
+        }
 
     def _set_data(self, X: pd.DataFrame, y: Sequence[str], copy_data: bool) -> None:
         if not all(isinstance(item, str) for item in y):  # type: ignore
@@ -1617,6 +1653,8 @@ class RRF:
             "random_state": self.random_state,
             "use_cumulative_memory": self.use_cumulative_memory,
             "question_scoring_f_beta": self.question_scoring_f_beta,
+            "semantic_filtering_during_fit": self.semantic_filtering_during_fit,
+            "semantic_similarity_threshold": self.semantic_similarity_threshold,
             "exclusion_log": self._exclusion_log,
         }
         with (base / "rrf.json").open("w", encoding="utf-8") as f:
@@ -1658,6 +1696,12 @@ class RRF:
             name=manifest["name"],
             use_cumulative_memory=manifest.get("use_cumulative_memory", True),
             question_scoring_f_beta=manifest.get("question_scoring_f_beta", 1.0),
+            semantic_filtering_during_fit=manifest.get(
+                "semantic_filtering_during_fit", False
+            ),
+            semantic_similarity_threshold=manifest.get(
+                "semantic_similarity_threshold", 0.9
+            ),
         )
 
         inst._task_description = manifest["task_description"]


### PR DESCRIPTION
## Summary
- Add `semantic_filtering_during_fit` and `semantic_similarity_threshold` params to RRF
- When enabled, near-duplicate questions are removed via `hashed_bag_of_words` embeddings **before** the expensive answering step, reducing LLM calls
- Includes `_last_fit_summary` dict, save/load support, input validation, and example docs

Fixes #44

## Test plan
- [x] 7 new offline tests in `TestEarlySemanticFiltering` (45 total passing)
- [x] `test_early_filter_reduces_llm_calls` — asserts fewer FakeLLM calls with early filtering vs baseline
- [x] `test_early_filter_disabled_by_default` — no regressions when feature is off
- [x] `test_early_filter_save_load_config` — round-trip preserves config
- [x] ruff clean, no new pyright errors

**Depends on:** PR #52 (batch predict) → PR #53 (exclusion report) → this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## ⚠️ Stack Position
**Depends on**: #52 (must merge first)
**Merge order**: After #52, before #55
**Stack**: #49 → #50 → #53 → #52 → **#54** → #55