### PR TITLE
feat: founder-level aggregation (fixes #47)

### DIFF
--- a/examples/rrf.py
+++ b/examples/rrf.py
@@ -9,6 +9,7 @@ A quick walkthrough of the Random Rule Forest (RRF) workflow:
   5. Compare F1 vs F-beta scoring
   6. Predict on new data
   7. Save / load and verify predictions match
+  8. Founder-level prediction with train/test split
 
 Prerequisites:
   export OPENAI_API_KEY="sk-..."
@@ -53,10 +54,11 @@ def print_df_compact(df: pd.DataFrame, cols: list[str], n: int = 5) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Toy dataset  (8 founder profiles)
+# Toy dataset  (20 founder profiles)
 # ---------------------------------------------------------------------------
 
 PERSONS = [
+    # --- Original 8 ---
     (
         "A: 30yo woman, CS Stanford, 6yr Google, AI healthcare startup, $2M seed.",
         "YES",
@@ -87,6 +89,55 @@ PERSONS = [
     ),
     (
         "H: 7 companies 3 industries, PM fintech startup, edutech idea.",
+        "NO",
+    ),
+    # --- Extra 12 for train/test split ---
+    (
+        "I: 35yo man, PhD robotics CMU, 4yr Tesla autopilot, autonomous drones.",
+        "YES",
+    ),
+    (
+        "J: 22yo woman, dropped out art school, sells NFTs, no revenue.",
+        "NO",
+    ),
+    (
+        "K: 38yo man, 2 prior exits (acqui-hired), SaaS analytics platform.",
+        "YES",
+    ),
+    (
+        "L: 29yo woman, biology PhD, first-time founder, biotech diagnostics.",
+        "NO",
+    ),
+    (
+        "M: 45yo man, 20yr banking VP, left Goldman, wealth-tech startup.",
+        "YES",
+    ),
+    (
+        "N: 26yo man, bootcamp grad, 1yr junior dev, wants to build CRM.",
+        "NO",
+    ),
+    (
+        "O: 33yo woman, ex-Stripe engineer, YC alum, payments API startup.",
+        "YES",
+    ),
+    (
+        "P: 30yo man, MBA Wharton, 2yr McKinsey, marketplace for tutors.",
+        "NO",
+    ),
+    (
+        "Q: 28yo woman, CS MIT, 3yr Meta AI research, computer vision startup.",
+        "YES",
+    ),
+    (
+        "R: 40yo man, real estate agent, no tech bg, proptech idea.",
+        "NO",
+    ),
+    (
+        "S: 31yo woman, ex-Airbnb PM, repeat founder, travel-tech platform.",
+        "YES",
+    ),
+    (
+        "T: 24yo man, economics major, no work exp, crypto trading bot.",
         "NO",
     ),
 ]
@@ -276,6 +327,52 @@ async def main() -> None:  # noqa: D103
 
     # Clean up
     shutil.rmtree(save_dir)
+
+    # ------------------------------------------------------------------
+    # 8. Founder-level prediction (issue #47)
+    # ------------------------------------------------------------------
+    print_section("8. Founder-level prediction (train/test split)")
+
+    # Split into train (first 16) / test (last 4) — 80/20
+    split_idx = 16
+    X_all = pd.DataFrame({"data": [p for p, _ in PERSONS]})
+    y_all = [label for _, label in PERSONS]
+    X_train, X_test = X_all.iloc[:split_idx], X_all.iloc[split_idx:]
+    y_train = y_all[:split_idx]
+    y_test = y_all[split_idx:]
+
+    print(f"Train: {len(X_train)} samples, Test: {len(X_test)} samples\n")
+
+    # Fit: generates questions, answers them, computes metrics,
+    # and tunes (K, T) for founder-level aggregation — all on train.
+    rrf_fl = RRF(
+        qgen_llmc=llm_choices,
+        name="example_founder_level",
+        max_samples_as_context=8,
+        max_generated_questions=8,
+        question_scoring_f_beta=0.5,
+    )
+    await rrf_fl.set_tasks(
+        task_description="Classify founders as likely to succeed or not"
+    )
+    await rrf_fl.fit(X_train, y_train, reset=True)
+
+    print(
+        f"Tuned aggregation: K={rrf_fl._aggregation_k}, "
+        f"T={rrf_fl._aggregation_t}\n"
+    )
+
+    # Predict on held-out test set
+    results = await rrf_fl.predict_founder_level(X_test)
+    print(results[["prediction", "yes_count"]].to_string())
+    print()
+
+    # Compare to ground truth
+    n_correct = sum(
+        results.loc[i, "prediction"] == y_test[j]
+        for j, i in enumerate(X_test.index)
+    )
+    print(f"Test accuracy: {n_correct}/{len(y_test)}")
     print("Done.")
 
 

--- a/examples/rrf.py
+++ b/examples/rrf.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pandas as pd
 
 from think_reason_learn.core.llms import OpenAIChoice
+from think_reason_learn.core.llms._schemas import LLMChoice
 from think_reason_learn.rrf import RRF
 
 
@@ -155,7 +156,7 @@ async def main() -> None:  # noqa: D103
     X = pd.DataFrame({"data": [p for p, _ in PERSONS]})
     y = [label for _, label in PERSONS]
 
-    llm_choices = [OpenAIChoice(model="gpt-4.1-nano")]
+    llm_choices: list[LLMChoice] = [OpenAIChoice(model="gpt-4.1-nano")]
 
     # ------------------------------------------------------------------
     # 1. Create RRF and generate questions
@@ -246,6 +247,7 @@ async def main() -> None:  # noqa: D103
     print_section("5. Exclusion report — why were questions dropped?")
 
     report = rrf.exclusion_report()
+    assert isinstance(report, pd.DataFrame)
     if len(report) == 0:
         print("No exclusions recorded.\n")
     else:
@@ -357,10 +359,7 @@ async def main() -> None:  # noqa: D103
     )
     await rrf_fl.fit(X_train, y_train, reset=True)
 
-    print(
-        f"Tuned aggregation: K={rrf_fl._aggregation_k}, "
-        f"T={rrf_fl._aggregation_t}\n"
-    )
+    print(f"Tuned aggregation: K={rrf_fl._aggregation_k}, T={rrf_fl._aggregation_t}\n")
 
     # Predict on held-out test set
     results = await rrf_fl.predict_founder_level(X_test)
@@ -369,8 +368,7 @@ async def main() -> None:  # noqa: D103
 
     # Compare to ground truth
     n_correct = sum(
-        results.loc[i, "prediction"] == y_test[j]
-        for j, i in enumerate(X_test.index)
+        results.loc[i, "prediction"] == y_test[j] for j, i in enumerate(X_test.index)
     )
     print(f"Test accuracy: {n_correct}/{len(y_test)}")
     print("Done.")

--- a/tests/test_rrf.py
+++ b/tests/test_rrf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import pandas as pd
 
@@ -1121,3 +1122,228 @@ class TestEarlySemanticFiltering:
 
         # Fewer total LLM calls because fewer questions were answered
         assert calls_early < calls_baseline
+
+
+# ---------------------------------------------------------------------------
+# founder-level prediction (issue #47)
+# ---------------------------------------------------------------------------
+
+
+class TestFounderPredictions:
+    """Tests for founder-level aggregation: aggregate_predictions,
+    _tune_aggregation (inside fit), and predict_founder_level."""
+
+    # -- static aggregate_predictions tests (no LLM) --
+
+    def test_aggregate_predictions_basic(self) -> None:
+        """Hand-crafted 4x3 matrix: verify correct aggregation."""
+        matrix = pd.DataFrame(
+            {
+                "q0": [1, 0, 1, 0],
+                "q1": [1, 1, 0, 0],
+                "q2": [0, 0, 1, 1],
+            },
+            index=pd.Index([0, 1, 2, 3]),
+        )
+        scores = pd.Series({"q0": 0.9, "q1": 0.7, "q2": 0.5})
+        # K=2: top questions are q0, q1
+        # yes_counts: [2, 1, 1, 0]
+        # T=1: predictions: [YES, YES, YES, NO]
+        result = RRF.aggregate_predictions(matrix, scores, k=2, t=1)
+        assert list(result) == ["YES", "YES", "YES", "NO"]
+
+    def test_aggregate_predictions_k1_t1(self) -> None:
+        """K=1, T=1: prediction equals top-scored question's column."""
+        matrix = pd.DataFrame(
+            {"q0": [1, 0, 1], "q1": [0, 1, 0]},
+            index=pd.Index([0, 1, 2]),
+        )
+        scores = pd.Series({"q0": 0.3, "q1": 0.8})
+        # Top question is q1 (score 0.8)
+        result = RRF.aggregate_predictions(matrix, scores, k=1, t=1)
+        assert list(result) == ["NO", "YES", "NO"]
+
+    def test_aggregate_predictions_all_yes(self) -> None:
+        """All-ones matrix: any T<=K should predict all YES."""
+        matrix = pd.DataFrame(
+            {"q0": [1, 1], "q1": [1, 1], "q2": [1, 1]},
+            index=pd.Index([0, 1]),
+        )
+        scores = pd.Series({"q0": 0.9, "q1": 0.7, "q2": 0.5})
+        for k in range(1, 4):
+            for t in range(1, k + 1):
+                result = RRF.aggregate_predictions(matrix, scores, k=k, t=t)
+                assert list(result) == ["YES", "YES"]
+
+    def test_aggregate_predictions_invalid_params(self) -> None:
+        """Invalid K/T raise ValueError."""
+        matrix = pd.DataFrame({"q0": [1], "q1": [0]}, index=pd.Index([0]))
+        scores = pd.Series({"q0": 0.9, "q1": 0.5})
+
+        with pytest.raises(ValueError, match="k must be"):
+            RRF.aggregate_predictions(matrix, scores, k=0, t=1)
+        with pytest.raises(ValueError, match="k must be"):
+            RRF.aggregate_predictions(matrix, scores, k=3, t=1)
+        with pytest.raises(ValueError, match="t must be"):
+            RRF.aggregate_predictions(matrix, scores, k=2, t=0)
+        with pytest.raises(ValueError, match="t must be"):
+            RRF.aggregate_predictions(matrix, scores, k=2, t=3)
+
+    # -- integration tests (FakeLLM) --
+
+    @pytest.mark.asyncio
+    async def test_fit_tunes_aggregation(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """After fit(), _aggregation_k and _aggregation_t are set."""
+        fake = FakeLLM(default_answer="ALTERNATE")
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_fit_tunes",
+            max_samples_as_context=8,
+            max_generated_questions=6,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        assert isinstance(rrf._aggregation_k, int)
+        assert isinstance(rrf._aggregation_t, int)
+        assert rrf._aggregation_k >= 1
+        assert rrf._aggregation_t >= 1
+
+    @pytest.mark.asyncio
+    async def test_predict_founder_level_after_fit(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """fit() then predict_founder_level(X) returns correct DataFrame."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pf_after_fit",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        result = await rrf.predict_founder_level(X)
+        assert isinstance(result, pd.DataFrame)
+        assert set(result.columns) == {"prediction", "yes_count", "k", "t"}
+        assert len(result) == len(X)
+        assert list(result.index) == list(X.index)
+
+    @pytest.mark.asyncio
+    async def test_predict_founder_level_explicit_params(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """predict_founder_level(X, k=1, t=1) works with explicit params."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pf_explicit",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        result = await rrf.predict_founder_level(X, k=1, t=1)
+        assert isinstance(result, pd.DataFrame)
+        assert (result["k"] == 1).all()
+        assert (result["t"] == 1).all()
+
+    @pytest.mark.asyncio
+    async def test_predict_founder_level_raises_without_fit(self) -> None:
+        """predict_founder_level without fit raises ValueError."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pf_no_fit",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake,
+        )
+        await rrf.set_tasks(task_description="Classify founders")
+        X = pd.DataFrame({"data": ["test person"]})
+        with pytest.raises(ValueError):
+            await rrf.predict_founder_level(X)
+
+    @pytest.mark.asyncio
+    async def test_predict_founder_level_all_yes_answers(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """FakeLLM(YES): all yes_count == K, all predictions YES."""
+        fake = FakeLLM(default_answer="YES")
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pf_all_yes",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        k = rrf._aggregation_k
+        assert k is not None
+        result = await rrf.predict_founder_level(X, k=k, t=1)
+        assert (result["prediction"] == "YES").all()
+        assert (result["yes_count"] == k).all()
+
+    @pytest.mark.asyncio
+    async def test_aggregation_save_load(
+        self,
+        sample_data: tuple[pd.DataFrame, list[str]],
+        tmp_path: object,
+    ) -> None:
+        """Save/load preserves aggregation K, T, and config params."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_agg_sl",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            aggregation_metric="precision",
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        save_dir = str(tmp_path)
+        rrf.save(save_dir)
+        loaded = RRF.load(save_dir)
+
+        assert loaded._aggregation_k == rrf._aggregation_k
+        assert loaded._aggregation_t == rrf._aggregation_t
+        assert loaded.aggregation_metric == "precision"
+
+    @pytest.mark.asyncio
+    async def test_predict_founder_level_output_contract(
+        self, sample_data: tuple[pd.DataFrame, list[str]]
+    ) -> None:
+        """Verify DataFrame columns, dtypes, and index alignment."""
+        fake = FakeLLM()
+        rrf = RRF(
+            qgen_llmc=LLM_CHOICE,
+            name="test_pf_contract",
+            max_samples_as_context=8,
+            max_generated_questions=3,
+            _llm=fake,
+        )
+        X, y = sample_data
+        await rrf.set_tasks(task_description="Classify founders")
+        await rrf.fit(X, y)
+
+        result = await rrf.predict_founder_level(X)
+        assert all(v in ("YES", "NO") for v in result["prediction"])
+        assert result["yes_count"].dtype in (np.int64, np.int32, int)
+        assert (result["k"] == rrf._aggregation_k).all()
+        assert (result["t"] == rrf._aggregation_t).all()

--- a/think_reason_learn/rrf/_rrf.py
+++ b/think_reason_learn/rrf/_rrf.py
@@ -124,9 +124,7 @@ class RRF:
         question_scoring_f_beta: float = 1.0,
         semantic_filtering_during_fit: bool = False,
         semantic_similarity_threshold: float = 0.9,
-        aggregation_metric: Literal[
-            "f1", "accuracy", "precision", "recall"
-        ] = "f1",
+        aggregation_metric: Literal["f1", "accuracy", "precision", "recall"] = "f1",
         aggregation_max_k: int | None = None,
         _llm: Any = None,
     ):
@@ -228,14 +226,11 @@ class RRF:
         val = kwargs["aggregation_metric"]
         if val not in ("f1", "accuracy", "precision", "recall"):
             raise ValueError(
-                "aggregation_metric must be 'f1', 'accuracy', "
-                "'precision', or 'recall'"
+                "aggregation_metric must be 'f1', 'accuracy', 'precision', or 'recall'"
             )
         val = kwargs["aggregation_max_k"]
         if val is not None and (not isinstance(val, int) or val < 1):
-            raise ValueError(
-                "aggregation_max_k must be None or a positive integer"
-            )
+            raise ValueError("aggregation_max_k must be None or a positive integer")
 
     def _get_name(self, name: str | None) -> str:
         if name is None:
@@ -483,8 +478,7 @@ class RRF:
 
             if self.use_cumulative_memory:
                 query = (
-                    f"SAMPLES:\n{samples_str}\n\n"
-                    f"CUMULATIVE MEMORY: {cumulative_memory}"
+                    f"SAMPLES:\n{samples_str}\n\nCUMULATIVE MEMORY: {cumulative_memory}"
                 )
             else:
                 query = f"SAMPLES:\n{samples_str}"
@@ -717,9 +711,7 @@ class RRF:
                 best_qid = cast(str, self._questions.index[indices[best]])
                 for r in group:
                     if r != best:
-                        loser_qid = cast(
-                            str, self._questions.index[indices[r]]
-                        )
+                        loser_qid = cast(str, self._questions.index[indices[r]])
                         sim_score = float(emb_matrix[r] @ emb_matrix[best])
                         self._exclusion_log.append(
                             {
@@ -1271,13 +1263,9 @@ class RRF:
         """
         n_questions = len(question_scores)
         if k < 1 or k > n_questions:
-            raise ValueError(
-                f"k must be between 1 and {n_questions}, got {k}"
-            )
+            raise ValueError(f"k must be between 1 and {n_questions}, got {k}")
         if t < 1 or t > k:
-            raise ValueError(
-                f"t must be between 1 and k={k}, got {t}"
-            )
+            raise ValueError(f"t must be between 1 and k={k}, got {t}")
 
         sorted_qids = question_scores.sort_values(ascending=False).index[:k]
         top_k = response_matrix[sorted_qids]
@@ -1309,15 +1297,11 @@ class RRF:
         binary = self._answers[active_qids].apply(
             lambda col: (col == "YES").astype(int)
         )
-        scores = self._questions.loc[
-            active_qids, "f_beta_score"
-        ].astype(float)
+        scores = self._questions.loc[active_qids, "f_beta_score"].astype(float)
         sorted_qids = scores.sort_values(ascending=False).index
         sorted_binary = binary[sorted_qids].values  # type: ignore[union-attr]
         cumsum = np.cumsum(sorted_binary, axis=1)  # type: ignore[arg-type]
-        y_true = np.array(
-            [1 if yi == "YES" else 0 for yi in self._y]
-        )
+        y_true = np.array([1 if yi == "YES" else 0 for yi in self._y])
 
         q_count = len(sorted_qids)
         max_k = (
@@ -1331,9 +1315,7 @@ class RRF:
             yes_at_k = cumsum[:, k - 1]
             for t_val in range(1, k + 1):
                 preds = (yes_at_k >= t_val).astype(int)
-                score = RRF._compute_metric(
-                    preds, y_true, self.aggregation_metric
-                )
+                score = RRF._compute_metric(preds, y_true, self.aggregation_metric)
                 if score > best_score:
                     best_score, best_k, best_t = score, k, t_val
 
@@ -1347,9 +1329,7 @@ class RRF:
             best_score,
         )
 
-    async def _build_response_matrix(
-        self, X: pd.DataFrame
-    ) -> pd.DataFrame:
+    async def _build_response_matrix(self, X: pd.DataFrame) -> pd.DataFrame:
         """Run predict() on X and build a binary response matrix.
 
         Returns:
@@ -1363,7 +1343,10 @@ class RRF:
         ]
 
         matrix = pd.DataFrame(
-            0, index=X.index, columns=active_qids, dtype=int  # type: ignore[arg-type]
+            0,
+            index=X.index,
+            columns=active_qids,  # type: ignore[arg-type]
+            dtype=int,
         )
 
         async for sample_idx, qid, answer, _tc in self.predict(X):
@@ -1431,17 +1414,11 @@ class RRF:
 
         matrix = await self._build_response_matrix(X)
         active_qids = list(matrix.columns)
-        scores = self._questions.loc[
-            active_qids, "f_beta_score"
-        ].astype(float)
+        scores = self._questions.loc[active_qids, "f_beta_score"].astype(float)
 
-        predictions = self.aggregate_predictions(
-            matrix, scores, k_val, t_val
-        )
+        predictions = self.aggregate_predictions(matrix, scores, k_val, t_val)
 
-        sorted_qids = scores.sort_values(
-            ascending=False
-        ).index[:k_val]
+        sorted_qids = scores.sort_values(ascending=False).index[:k_val]
         yes_counts = matrix[sorted_qids].sum(axis=1)
 
         return pd.DataFrame(
@@ -1887,11 +1864,13 @@ class RRF:
             qdf = self._questions.copy()
             if "embedding" in qdf.columns:
                 qdf["embedding"] = qdf["embedding"].apply(  # type: ignore
-                    lambda x: orjson.dumps(  # type: ignore
-                        x.tolist() if isinstance(x, np.ndarray) else x
-                    ).decode()
-                    if x is not None
-                    else None
+                    lambda x: (
+                        orjson.dumps(  # type: ignore
+                            x.tolist() if isinstance(x, np.ndarray) else x
+                        ).decode()
+                        if x is not None
+                        else None
+                    )
                 )
             qdf.to_parquet(base / "questions.parquet")  # type: ignore
 
@@ -1991,9 +1970,7 @@ class RRF:
             semantic_similarity_threshold=manifest.get(
                 "semantic_similarity_threshold", 0.9
             ),
-            aggregation_metric=manifest.get(
-                "aggregation_metric", "f1"
-            ),
+            aggregation_metric=manifest.get("aggregation_metric", "f1"),
             aggregation_max_k=manifest.get("aggregation_max_k"),
         )
 
@@ -2012,9 +1989,11 @@ class RRF:
         qdf = pd.read_parquet(q_path)  # type: ignore
         if "embedding" in qdf.columns:
             qdf["embedding"] = qdf["embedding"].apply(  # type: ignore
-                lambda x: np.array(orjson.loads(x), dtype=np.float32)  # type: ignore
-                if x is not None
-                else None
+                lambda x: (
+                    np.array(orjson.loads(x), dtype=np.float32)  # type: ignore
+                    if x is not None
+                    else None
+                )
             )
         for col in [
             "excluded_in_semantics",

--- a/think_reason_learn/rrf/_rrf.py
+++ b/think_reason_learn/rrf/_rrf.py
@@ -96,6 +96,12 @@ class RRF:
         semantic_similarity_threshold: Cosine-similarity threshold used for
             early semantic filtering. Only relevant when
             ``semantic_filtering_during_fit=True``. Default 0.9.
+        aggregation_metric: Metric optimized when tuning (K, T) for
+            founder-level prediction during ``fit()``. One of ``"f1"``,
+            ``"accuracy"``, ``"precision"``, ``"recall"``. Default ``"f1"``.
+        aggregation_max_k: Maximum K (number of top questions) to consider
+            during (K, T) grid search. ``None`` means use all active
+            questions. Default ``None``.
     """
 
     def __init__(
@@ -118,6 +124,10 @@ class RRF:
         question_scoring_f_beta: float = 1.0,
         semantic_filtering_during_fit: bool = False,
         semantic_similarity_threshold: float = 0.9,
+        aggregation_metric: Literal[
+            "f1", "accuracy", "precision", "recall"
+        ] = "f1",
+        aggregation_max_k: int | None = None,
         _llm: Any = None,
     ):
         locals_dict = deepcopy(locals())
@@ -143,9 +153,13 @@ class RRF:
         self.question_scoring_f_beta = question_scoring_f_beta
         self.semantic_filtering_during_fit = semantic_filtering_during_fit
         self.semantic_similarity_threshold = semantic_similarity_threshold
+        self.aggregation_metric = aggregation_metric
+        self.aggregation_max_k = aggregation_max_k
         self._llm_instance: Any = _llm if _llm is not None else llm
         self._exclusion_log: list[dict[str, Any]] = []
         self._last_fit_summary: dict[str, Any] = {}
+        self._aggregation_k: int | None = None
+        self._aggregation_t: int | None = None
 
         self._token_counter: TokenCounter = TokenCounter()
 
@@ -211,6 +225,17 @@ class RRF:
         val = kwargs["semantic_similarity_threshold"]
         if not (isinstance(val, (int, float)) and 0 <= val <= 1):
             raise ValueError("semantic_similarity_threshold must be between 0 and 1")
+        val = kwargs["aggregation_metric"]
+        if val not in ("f1", "accuracy", "precision", "recall"):
+            raise ValueError(
+                "aggregation_metric must be 'f1', 'accuracy', "
+                "'precision', or 'recall'"
+            )
+        val = kwargs["aggregation_max_k"]
+        if val is not None and (not isinstance(val, int) or val < 1):
+            raise ValueError(
+                "aggregation_max_k must be None or a positive integer"
+            )
 
     def _get_name(self, name: str | None) -> str:
         if name is None:
@@ -1181,6 +1206,254 @@ class RRF:
             self._questions.at[qid, "f_beta_score"] = f_beta
             self._questions.at[qid, "accuracy"] = accuracy
 
+    # ------------------------------------------------------------------
+    # Founder-level aggregation (issue #47)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_metric(
+        preds: npt.NDArray[np.int_],
+        y_true: npt.NDArray[np.int_],
+        metric: str,
+    ) -> float:
+        """Compute a classification metric from binary arrays.
+
+        Args:
+            preds: Predicted labels (0/1).
+            y_true: True labels (0/1).
+            metric: One of "f1", "accuracy", "precision", "recall".
+
+        Returns:
+            The metric value as a float.
+        """
+        tp = int(((preds == 1) & (y_true == 1)).sum())
+        tn = int(((preds == 0) & (y_true == 0)).sum())
+        fp = int(((preds == 1) & (y_true == 0)).sum())
+        fn = int(((preds == 0) & (y_true == 1)).sum())
+        total = tp + tn + fp + fn
+
+        if metric == "accuracy":
+            return (tp + tn) / total if total else 0.0
+        if metric == "precision":
+            return tp / (tp + fp) if (tp + fp) else 0.0
+        if metric == "recall":
+            return tp / (tp + fn) if (tp + fn) else 0.0
+        if metric == "f1":
+            p = tp / (tp + fp) if (tp + fp) else 0.0
+            r = tp / (tp + fn) if (tp + fn) else 0.0
+            return 2 * p * r / (p + r) if (p + r) else 0.0
+        raise ValueError(f"Unknown metric: {metric}")
+
+    @staticmethod
+    def aggregate_predictions(
+        response_matrix: pd.DataFrame,
+        question_scores: pd.Series,
+        k: int,
+        t: int,
+    ) -> pd.Series:
+        """Aggregate per-question binary responses into founder-level labels.
+
+        Selects the top-K questions by score (descending) and predicts YES
+        for a founder if at least T of those K questions are answered YES.
+
+        Args:
+            response_matrix: Binary DataFrame (n_samples x n_questions)
+                with values 0 (NO) or 1 (YES).
+            question_scores: Float scores indexed by question ID.
+            k: Number of top-scoring questions to use.
+            t: Minimum YES count to predict "YES".
+
+        Returns:
+            Series of "YES"/"NO" predictions indexed by sample.
+
+        Raises:
+            ValueError: If k or t are out of valid range.
+        """
+        n_questions = len(question_scores)
+        if k < 1 or k > n_questions:
+            raise ValueError(
+                f"k must be between 1 and {n_questions}, got {k}"
+            )
+        if t < 1 or t > k:
+            raise ValueError(
+                f"t must be between 1 and k={k}, got {t}"
+            )
+
+        sorted_qids = question_scores.sort_values(ascending=False).index[:k]
+        top_k = response_matrix[sorted_qids]
+        yes_counts = top_k.sum(axis=1)
+        return pd.Series(
+            np.where(yes_counts >= t, "YES", "NO"),
+            index=response_matrix.index,
+        )
+
+    def _tune_aggregation(self) -> None:
+        """Find best (K, T) on training data via grid search.
+
+        Uses the already-computed ``_answers`` DataFrame and ``_y`` labels.
+        No additional LLM calls are made. Stores results in
+        ``_aggregation_k`` and ``_aggregation_t``.
+        """
+        if self._y is None:
+            return
+
+        active_qids = [
+            cast(str, qid)
+            for qid in self._questions.index
+            if self._questions.at[qid, "exclusion"] is None
+            and qid in self._answers.columns
+        ]
+        if not active_qids:
+            return
+
+        binary = self._answers[active_qids].apply(
+            lambda col: (col == "YES").astype(int)
+        )
+        scores = self._questions.loc[
+            active_qids, "f_beta_score"
+        ].astype(float)
+        sorted_qids = scores.sort_values(ascending=False).index
+        sorted_binary = binary[sorted_qids].values  # type: ignore[union-attr]
+        cumsum = np.cumsum(sorted_binary, axis=1)  # type: ignore[arg-type]
+        y_true = np.array(
+            [1 if yi == "YES" else 0 for yi in self._y]
+        )
+
+        q_count = len(sorted_qids)
+        max_k = (
+            min(self.aggregation_max_k, q_count)
+            if self.aggregation_max_k is not None
+            else q_count
+        )
+
+        best_score, best_k, best_t = -1.0, 1, 1
+        for k in range(1, max_k + 1):
+            yes_at_k = cumsum[:, k - 1]
+            for t_val in range(1, k + 1):
+                preds = (yes_at_k >= t_val).astype(int)
+                score = RRF._compute_metric(
+                    preds, y_true, self.aggregation_metric
+                )
+                if score > best_score:
+                    best_score, best_k, best_t = score, k, t_val
+
+        self._aggregation_k = best_k
+        self._aggregation_t = best_t
+        logger.info(
+            "Aggregation tuned: K=%d, T=%d (%s=%.4f)",
+            best_k,
+            best_t,
+            self.aggregation_metric,
+            best_score,
+        )
+
+    async def _build_response_matrix(
+        self, X: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Run predict() on X and build a binary response matrix.
+
+        Returns:
+            DataFrame of shape (n_samples, n_active_questions) with int
+            values 1 (YES) or 0 (NO).
+        """
+        active_qids = [
+            cast(str, qid)
+            for qid in self._questions.index
+            if self._questions.at[qid, "exclusion"] is None
+        ]
+
+        matrix = pd.DataFrame(
+            0, index=X.index, columns=active_qids, dtype=int  # type: ignore[arg-type]
+        )
+
+        async for sample_idx, qid, answer, _tc in self.predict(X):
+            matrix.at[sample_idx, qid] = 1 if answer == "YES" else 0
+
+        return matrix
+
+    async def predict_founder_level(
+        self,
+        X: pd.DataFrame,
+        *,
+        k: int | None = None,
+        t: int | None = None,
+    ) -> pd.DataFrame:
+        """Founder-level binary predictions using top-K / threshold-T.
+
+        Calls ``predict()`` internally to get per-question answers, then
+        aggregates using the top-K questions (ranked by f_beta_score) and
+        a YES-count threshold T.
+
+        K and T are learned during ``fit()`` via grid search on training
+        data. You can override them with explicit arguments.
+
+        Note:
+            K/T are tuned on training data (same data used for question
+            scoring). For stricter separation, pass explicit ``k`` and
+            ``t`` values tuned on a held-out validation set.
+
+        Example::
+
+            # sklearn-style workflow
+            rrf = RRF(qgen_llmc=llm_choices, name="my_rrf")
+            await rrf.set_tasks(task_description="Classify founders")
+            await rrf.fit(X_train, y_train)
+
+            # Predict on new data
+            results = await rrf.predict_founder_level(X_test)
+            print(results[["prediction", "yes_count"]])
+
+        Args:
+            X: Samples to predict (same format as fit input).
+            k: Number of top questions to use. Defaults to the value
+                learned during fit.
+            t: Minimum YES count to predict "YES". Defaults to the
+                value learned during fit.
+
+        Returns:
+            DataFrame with columns:
+                - prediction: "YES" or "NO"
+                - yes_count: number of YES answers among top-K questions
+                - k: the K value used
+                - t: the T value used
+            Index matches X.index.
+
+        Raises:
+            ValueError: If k/t not provided and not learned during fit.
+        """
+        k_val = k if k is not None else self._aggregation_k
+        t_val = t if t is not None else self._aggregation_t
+        if k_val is None or t_val is None:
+            raise ValueError(
+                "k and t must be provided explicitly or learned "
+                "via fit(). Call fit() first or pass k and t."
+            )
+
+        matrix = await self._build_response_matrix(X)
+        active_qids = list(matrix.columns)
+        scores = self._questions.loc[
+            active_qids, "f_beta_score"
+        ].astype(float)
+
+        predictions = self.aggregate_predictions(
+            matrix, scores, k_val, t_val
+        )
+
+        sorted_qids = scores.sort_values(
+            ascending=False
+        ).index[:k_val]
+        yes_counts = matrix[sorted_qids].sum(axis=1)
+
+        return pd.DataFrame(
+            {
+                "prediction": predictions,
+                "yes_count": yes_counts,
+                "k": k_val,
+                "t": t_val,
+            },
+            index=X.index,
+        )
+
     def _jaccard_similarity(self, col1: pd.Series, col2: pd.Series) -> float:
         set1 = set(col1.index[col1 == "YES"])  # type: ignore
         set2 = set(col2.index[col2 == "YES"])  # type: ignore
@@ -1323,6 +1596,9 @@ class RRF:
         logger.info("Setting questions metrics")
         self._set_questions_metrics()
 
+        logger.info("Tuning founder-level aggregation (K, T)")
+        self._tune_aggregation()
+
         self._last_fit_summary = {
             "questions_generated": n_generated,
             "questions_after_early_filter": n_after_filter,
@@ -1362,6 +1638,15 @@ class RRF:
         reset: bool = False,
     ) -> Self:
         """Fit the RRF to the data.
+
+        Generates questions, answers them on the provided data, computes
+        per-question metrics, and tunes (K, T) for founder-level
+        aggregation via ``predict_founder_level()``.
+
+        Note:
+            (K, T) are tuned on the data passed to ``fit()``. For
+            unbiased evaluation, fit on training data and evaluate on
+            a held-out test set.
 
         Args:
             X: Training features. Required on first run or with reset=True.
@@ -1656,6 +1941,10 @@ class RRF:
             "semantic_filtering_during_fit": self.semantic_filtering_during_fit,
             "semantic_similarity_threshold": self.semantic_similarity_threshold,
             "exclusion_log": self._exclusion_log,
+            "aggregation_metric": self.aggregation_metric,
+            "aggregation_max_k": self.aggregation_max_k,
+            "aggregation_k": self._aggregation_k,
+            "aggregation_t": self._aggregation_t,
         }
         with (base / "rrf.json").open("w", encoding="utf-8") as f:
             f.write(orjson.dumps(manifest).decode())
@@ -1702,12 +1991,18 @@ class RRF:
             semantic_similarity_threshold=manifest.get(
                 "semantic_similarity_threshold", 0.9
             ),
+            aggregation_metric=manifest.get(
+                "aggregation_metric", "f1"
+            ),
+            aggregation_max_k=manifest.get("aggregation_max_k"),
         )
 
         inst._task_description = manifest["task_description"]
         inst._qgen_instructions_template = manifest["qgen_instructions_template"]
         inst._last_emb_model = manifest["last_emb_model"]
         inst._exclusion_log = manifest.get("exclusion_log", [])
+        inst._aggregation_k = manifest.get("aggregation_k")
+        inst._aggregation_t = manifest.get("aggregation_t")
         if tk_dict := manifest["token_counter"]:
             inst._token_counter = TokenCounter.from_dict(tk_dict)
 


### PR DESCRIPTION
## Summary

- Add `predict_founder_level()` method for top-K / threshold-T binary predictions per founder
- K and T are tuned automatically during `fit()` via grid search on training data (no extra LLM calls — reuses existing `_answers` DataFrame)
- Add `aggregate_predictions()` static method for pure vectorised aggregation (testable independently)
- New constructor params: `aggregation_metric` (default `"f1"`), `aggregation_max_k` (default `None`)
- Learned state (`_aggregation_k`, `_aggregation_t`) saved/loaded with model
- Expand example to 20 founders with train/test split demonstrating the sklearn-style workflow
- 11 new offline tests (56 total), all using FakeLLM

Fixes #47

**Depends on:** PR #54 (early semantic filtering). Merge #49 → #50 → #53 → #52 → #54 → this PR.

## Test plan

- [x] 56 tests pass (`pytest tests/test_rrf.py -q`)
- [x] `ruff check .` — all clean
- [x] `pyright` — 19 errors (18 pre-existing + 1 same-pattern false positive in new example code)
- [x] Manual review of `examples/rrf.py` section 8 (requires `OPENAI_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## ⚠️ Stack Position
**Depends on**: #54 (must merge first)
**Merge order**: After #54
**Stack**: #49 → #50 → #53 → #52 → #54 → **#55** → #58
**Note**: #58 (cost-sensitive mode) has been rebased on top of this PR and should merge after it.