### PR TITLE
feat: GPTree testability, timing instrumentation, and answer cache

### DIFF
--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -1,10 +1,10 @@
-"""Deterministic fake LLM for offline RRF testing."""
+"""Deterministic fake LLM for offline RRF and GPTree testing."""
 
 from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict, List, Literal, Type
+from typing import Any, Dict, List, Literal, Type, get_args, get_origin
 
 from think_reason_learn.core.llms._schemas import (
     LLMChoice,
@@ -14,26 +14,62 @@ from think_reason_learn.core.llms._schemas import (
     T,
 )
 from think_reason_learn.core.llms import OpenAIChoice
-from think_reason_learn.rrf._rrf import Answer, Questions
+from think_reason_learn.rrf._rrf import Answer as RRFAnswer
+from think_reason_learn.rrf._rrf import Questions as RRFQuestions
 from think_reason_learn.rrf._prompts import num_questions_tag
+from think_reason_learn.gptree._gptree import Question as GPTreeQuestion
+from think_reason_learn.gptree._gptree import Questions as GPTreeQuestions
 
 
 _FAKE_PROVIDER = OpenAIChoice(model="gpt-4.1-nano")
 
 
+def _is_gptree_questions(response_format: type) -> bool:
+    """Check if response_format is GPTree's Questions (List[Question] not List[str])."""
+    return response_format is GPTreeQuestions
+
+
+def _is_rrf_questions(response_format: type) -> bool:
+    """Check if response_format is RRF's Questions (List[str])."""
+    return response_format is RRFQuestions
+
+
+def _is_dynamic_answer_model(response_format: type) -> bool:
+    """Check for dynamically-created Answer model.
+
+    GPTree's _make_answer_model creates models with name "Answer"
+    and a single ``answer`` field whose annotation is a Literal type.
+    """
+    if getattr(response_format, "__name__", None) != "Answer":
+        return False
+    # Exclude the static RRF Answer class
+    if response_format is RRFAnswer:
+        return False
+    # Check for a Literal-typed answer field (dynamic model from create_model)
+    fields = getattr(response_format, "model_fields", {})
+    answer_field = fields.get("answer")
+    if answer_field is None:
+        return False
+    annotation = answer_field.annotation
+    return get_origin(annotation) is Literal
+
+
 class FakeLLM:
     """Drop-in replacement for ``LLM`` that returns canned responses.
 
-    Dispatches based on ``response_format`` to handle the 4 RRF call sites:
+    Dispatches based on ``response_format`` to handle call sites from both
+    RRF and GPTree:
 
+    **RRF call sites:**
     1. ``set_tasks``  (``str``)  -- template with ``<number_of_questions>`` tag
-    2. ``_generate_questions``  (``Questions``)  -- pydantic model
-    3. ``_answer_single_question``  (``Answer``)  -- pydantic model
+    2. ``_generate_questions``  (``RRFQuestions``)  -- pydantic model
+    3. ``_answer_single_question``  (``RRFAnswer``)  -- pydantic model
     4. ``_answer_questions_batch``  (``str``)  -- JSON list
 
-    The two ``str``-typed sites are distinguished by query content:
-    ``set_tasks`` sends ``"Generate YES/NO questions for:..."`` while
-    batch sends ``"You are a VC analyst..."``.
+    **GPTree call sites:**
+    1. ``set_tasks``  (``str``)  -- query contains "Build a decision tree"
+    2. ``_generate_questions``  (``GPTreeQuestions``)  -- pydantic model
+    3. ``_answer_question_for_row``  (dynamic ``Answer``)  -- Literal-typed choices
 
     Args:
         default_answer: ``"YES"``, ``"NO"``, or ``"ALTERNATE"``.
@@ -82,25 +118,41 @@ class FakeLLM:
             }
         )
 
-        if response_format is Questions:
-            return self._questions_response()
-        if response_format is Answer:
-            return self._answer_response()
-        if response_format is not str:
-            raise TypeError(
-                f"FakeLLM: unknown response_format {response_format!r}. "
-                "Add a handler for this new call site."
-            )
-        # response_format is str — distinguish set_tasks vs batch by query
-        if "generate yes/no" in query.lower():
-            return self._set_tasks_response()
-        return self._batch_answer_response(query)
+        # --- Pydantic model dispatch (by identity, then by introspection) ---
+
+        if _is_rrf_questions(response_format):
+            return self._rrf_questions_response()
+
+        if _is_gptree_questions(response_format):
+            return self._gptree_questions_response()
+
+        if response_format is RRFAnswer:
+            return self._rrf_answer_response()
+
+        if _is_dynamic_answer_model(response_format):
+            fields = getattr(response_format, "model_fields", {})
+            choices = get_args(fields["answer"].annotation)
+            return self._gptree_answer_response(response_format, choices)
+
+        # --- str dispatch (set_tasks vs batch, RRF vs GPTree) ---
+
+        if response_format is str:
+            if "generate yes/no" in query.lower():
+                return self._rrf_set_tasks_response()
+            if "build a decision tree" in query.lower():
+                return self._gptree_set_tasks_response()
+            return self._rrf_batch_answer_response(query)
+
+        raise TypeError(
+            f"FakeLLM: unknown response_format {response_format!r}. "
+            "Add a handler for this new call site."
+        )
 
     # ------------------------------------------------------------------
-    # Canned responses
+    # RRF canned responses
     # ------------------------------------------------------------------
 
-    def _set_tasks_response(self) -> LLMResponse[str]:
+    def _rrf_set_tasks_response(self) -> LLMResponse[str]:
         return LLMResponse(
             response=(
                 f"Generate {num_questions_tag} YES/NO questions to determine "
@@ -111,13 +163,13 @@ class FakeLLM:
             provider_model=_FAKE_PROVIDER,
         )
 
-    def _questions_response(self) -> LLMResponse[Questions]:
+    def _rrf_questions_response(self) -> LLMResponse[RRFQuestions]:
         qs = [
             f"Does the person have relevant technical experience? (variant {i})"
             for i in range(self.questions_per_call)
         ]
         return LLMResponse(
-            response=Questions(
+            response=RRFQuestions(
                 questions=qs,
                 cumulative_memory="Fake memory: technical background matters.",
             ),
@@ -126,21 +178,68 @@ class FakeLLM:
             provider_model=_FAKE_PROVIDER,
         )
 
-    def _answer_response(self) -> LLMResponse[Answer]:
+    def _rrf_answer_response(self) -> LLMResponse[RRFAnswer]:
         return LLMResponse(
-            response=Answer(answer=self._get_answer(self._call_count)),
+            response=RRFAnswer(answer=self._get_answer(self._call_count)),
             logprobs=[("YES", -0.01)],
             total_tokens=15,
             provider_model=_FAKE_PROVIDER,
         )
 
-    def _batch_answer_response(self, query: str) -> LLMResponse[str]:
+    def _rrf_batch_answer_response(self, query: str) -> LLMResponse[str]:
         indices = [int(m) for m in re.findall(r"Sample (\d+):", query)]
         results = [{"sample_index": i, "answer": self._get_answer(i)} for i in indices]
         return LLMResponse(
             response=json.dumps(results),
             logprobs=[],
             total_tokens=20 * max(len(indices), 1),
+            provider_model=_FAKE_PROVIDER,
+        )
+
+    # ------------------------------------------------------------------
+    # GPTree canned responses
+    # ------------------------------------------------------------------
+
+    def _gptree_set_tasks_response(self) -> LLMResponse[str]:
+        return LLMResponse(
+            response=(
+                f"Generate {num_questions_tag} discriminative questions for "
+                "the classification task. Each question should have clear, "
+                "mutually exclusive answer choices."
+            ),
+            logprobs=[("t", -0.1)],
+            total_tokens=50,
+            provider_model=_FAKE_PROVIDER,
+        )
+
+    def _gptree_questions_response(self) -> LLMResponse[GPTreeQuestions]:
+        qs = [
+            GPTreeQuestion(
+                value=f"Does the founder have trait {i}?",
+                choices=["Yes", "No"],
+                question_type="INFERENCE",
+            )
+            for i in range(self.questions_per_call)
+        ]
+        return LLMResponse(
+            response=GPTreeQuestions(
+                questions=qs,
+                cumulative_memory="Fake memory: observed patterns in backgrounds.",
+            ),
+            logprobs=[("t", -0.05)],
+            total_tokens=100,
+            provider_model=_FAKE_PROVIDER,
+        )
+
+    def _gptree_answer_response(
+        self, response_format: type, choices: tuple[str, ...]
+    ) -> LLMResponse[Any]:
+        """Return an answer cycling through available choices."""
+        chosen = choices[self._call_count % len(choices)]
+        return LLMResponse(
+            response=response_format(answer=chosen),
+            logprobs=[("ans", -0.01)],
+            total_tokens=15,
             provider_model=_FAKE_PROVIDER,
         )
 

--- a/tests/test_fake_llm.py
+++ b/tests/test_fake_llm.py
@@ -1,0 +1,181 @@
+"""Tests for FakeLLM dispatch — ensures both RRF and GPTree call sites work."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from pydantic import create_model
+
+from tests.fake_llm import FakeLLM
+from think_reason_learn.core.llms import LLMChoice, OpenAIChoice
+from think_reason_learn.rrf._rrf import Answer as RRFAnswer
+from think_reason_learn.rrf._rrf import Questions as RRFQuestions
+from think_reason_learn.gptree._gptree import Questions as GPTreeQuestions
+
+_LLM_PRIORITY: list[LLMChoice] = [OpenAIChoice(model="gpt-4.1-nano")]
+
+
+# ---------------------------------------------------------------------------
+# RRF dispatch (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+class TestRRFDispatch:
+    """Verify existing RRF behaviour is preserved after refactor."""
+
+    @pytest.mark.asyncio
+    async def test_rrf_questions(self) -> None:
+        fake = FakeLLM(questions_per_call=3)
+        resp = await fake.respond(
+            query="samples",
+            llm_priority=_LLM_PRIORITY,
+            response_format=RRFQuestions,
+        )
+        assert isinstance(resp.response, RRFQuestions)
+        assert len(resp.response.questions) == 3
+        assert isinstance(resp.response.questions[0], str)
+
+    @pytest.mark.asyncio
+    async def test_rrf_answer(self) -> None:
+        fake = FakeLLM(default_answer="YES")
+        resp = await fake.respond(
+            query="question",
+            llm_priority=_LLM_PRIORITY,
+            response_format=RRFAnswer,
+        )
+        assert isinstance(resp.response, RRFAnswer)
+        assert resp.response.answer == "YES"
+
+    @pytest.mark.asyncio
+    async def test_rrf_set_tasks(self) -> None:
+        fake = FakeLLM()
+        resp = await fake.respond(
+            query="Generate YES/NO questions for: classifying founders",
+            llm_priority=_LLM_PRIORITY,
+            response_format=str,
+        )
+        assert "<number_of_questions>" in str(resp.response)
+
+    @pytest.mark.asyncio
+    async def test_rrf_batch_answer(self) -> None:
+        fake = FakeLLM(default_answer="YES")
+        resp = await fake.respond(
+            query="You are a VC analyst. Sample 0: Alice Sample 1: Bob",
+            llm_priority=_LLM_PRIORITY,
+            response_format=str,
+        )
+        assert '"answer"' in str(resp.response)
+
+
+# ---------------------------------------------------------------------------
+# GPTree dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGPTreeDispatch:
+    """Verify GPTree call sites dispatch correctly."""
+
+    @pytest.mark.asyncio
+    async def test_gptree_questions(self) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        resp = await fake.respond(
+            query="samples with label successful...",
+            llm_priority=_LLM_PRIORITY,
+            response_format=GPTreeQuestions,
+        )
+        assert isinstance(resp.response, GPTreeQuestions)
+        assert len(resp.response.questions) == 2
+        q = resp.response.questions[0]
+        assert hasattr(q, "value")
+        assert hasattr(q, "choices")
+        assert q.question_type == "INFERENCE"
+
+    @pytest.mark.asyncio
+    async def test_gptree_dynamic_answer(self) -> None:
+        """Dynamic Answer model from _make_answer_model (Literal choices)."""
+        DynAnswer = create_model("Answer", answer=(Literal["Yes", "No"], ...))
+        fake = FakeLLM()
+        resp = await fake.respond(
+            query="Query: Q?\n\nSample: some text",
+            llm_priority=_LLM_PRIORITY,
+            response_format=DynAnswer,
+        )
+        assert resp.response.answer in ("Yes", "No")  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_gptree_dynamic_answer_three_choices(self) -> None:
+        """Dynamic Answer with 3 choices cycles through them."""
+        DynAnswer = create_model(
+            "Answer", answer=(Literal["High", "Medium", "Low"], ...)
+        )
+        fake = FakeLLM()
+        answers = []
+        for _ in range(6):
+            resp = await fake.respond(
+                query="Query: Q?\n\nSample: text",
+                llm_priority=_LLM_PRIORITY,
+                response_format=DynAnswer,
+            )
+            answers.append(resp.response.answer)  # type: ignore[union-attr]
+        # Should cycle through all 3 choices
+        assert set(answers) == {"High", "Medium", "Low"}
+
+    @pytest.mark.asyncio
+    async def test_gptree_set_tasks(self) -> None:
+        fake = FakeLLM()
+        resp = await fake.respond(
+            query="Build a decision tree for:\nClassifying founders",
+            llm_priority=_LLM_PRIORITY,
+            response_format=str,
+        )
+        assert "<number_of_questions>" in str(resp.response)
+
+    @pytest.mark.asyncio
+    async def test_gptree_answer_cycles_choices(self) -> None:
+        """Answers cycle through choices for non-degenerate splits."""
+        DynAnswer = create_model("Answer", answer=(Literal["Yes", "No"], ...))
+        fake = FakeLLM()
+        answers = []
+        for _ in range(4):
+            resp = await fake.respond(
+                query="Query: Q?\n\nSample: text",
+                llm_priority=_LLM_PRIORITY,
+                response_format=DynAnswer,
+            )
+            answers.append(resp.response.answer)  # type: ignore[union-attr]
+        # With cycling, should see both values
+        assert "Yes" in answers
+        assert "No" in answers
+
+
+# ---------------------------------------------------------------------------
+# Call tracking
+# ---------------------------------------------------------------------------
+
+
+class TestCallTracking:
+    """Verify call count and reset work across both RRF and GPTree calls."""
+
+    @pytest.mark.asyncio
+    async def test_call_count_increments(self) -> None:
+        fake = FakeLLM()
+        assert fake.call_count == 0
+        await fake.respond("q", _LLM_PRIORITY, RRFQuestions)
+        assert fake.call_count == 1
+        await fake.respond("q", _LLM_PRIORITY, GPTreeQuestions)
+        assert fake.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_state(self) -> None:
+        fake = FakeLLM()
+        await fake.respond("q", _LLM_PRIORITY, RRFQuestions)
+        fake.reset()
+        assert fake.call_count == 0
+        assert fake.calls == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_format_raises(self) -> None:
+        fake = FakeLLM()
+        with pytest.raises(TypeError, match="unknown response_format"):
+            await fake.respond("q", _LLM_PRIORITY, int)  # type: ignore

--- a/tests/test_gptree.py
+++ b/tests/test_gptree.py
@@ -1,12 +1,14 @@
-"""Tests for GPTree class-weighted Gini and threshold predictions."""
+"""Tests for GPTree class-weighted Gini, threshold predictions, and integration."""
 
 from __future__ import annotations
 
 from typing import Any
 
 import numpy as np
+import pandas as pd
 import pytest
 
+from tests.fake_llm import FakeLLM
 from think_reason_learn.core.llms import OpenAIChoice
 from think_reason_learn.gptree import GPTree, Node
 
@@ -22,6 +24,41 @@ def _make_tree(**kwargs: Any) -> GPTree:
         qgen_instr_llmc=kwargs.pop("qgen_instr_llmc", _DUMMY_LLM),
         **kwargs,
     )
+
+
+def _tiny_dataset() -> tuple[pd.DataFrame, list[str]]:
+    """6 samples with 1 prose column and binary labels."""
+    data = {
+        "prose": [
+            "Alice is a software engineer with 10 years experience at Google",
+            "Bob is a marketing intern with no startup experience",
+            "Charlie is a serial entrepreneur with 2 prior exits",
+            "Diana is a recent graduate from a local college",
+            "Eve is a VP of engineering at a Fortune 500 company",
+            "Frank is a freelance graphic designer with varied clients",
+        ]
+    }
+    labels = ["successful", "failed", "successful", "failed", "successful", "failed"]
+    return pd.DataFrame(data), labels
+
+
+def _make_integration_tree(
+    fake: FakeLLM, *, tmp_path: Any = None, **kwargs: Any
+) -> GPTree:
+    """Create a GPTree wired to FakeLLM for integration tests."""
+    defaults: dict[str, Any] = {
+        "max_depth": 2,
+        "min_samples_leaf": 1,
+        "min_question_candidates": 2,
+        "max_question_candidates": 2,
+        "n_samples_as_context": 3,
+        "random_state": 42,
+    }
+    defaults.update(kwargs)
+    if tmp_path is not None:
+        defaults.setdefault("save_path", str(tmp_path))
+        defaults.setdefault("name", "test_tree")
+    return _make_tree(_llm=fake, **defaults)
 
 
 def _set_y(tree: GPTree, y: list[str]) -> None:
@@ -269,3 +306,279 @@ class TestBackwardCompat:
         _set_y(tree, ["failed"] * 90 + ["successful"] * 10)
         indices = np.arange(100, dtype=np.intp)
         assert tree._gini(indices) == pytest.approx(0.18)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (FakeLLM)
+# ---------------------------------------------------------------------------
+
+
+class TestSetTasksIntegration:
+    """Test set_tasks() with FakeLLM."""
+
+    @pytest.mark.asyncio
+    async def test_generates_template_from_description(self) -> None:
+        fake = FakeLLM()
+        tree = _make_integration_tree(fake)
+        template = await tree.set_tasks(
+            task_description="Classify founders as successful or not"
+        )
+        assert "<number_of_questions>" in template
+        assert fake.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_template_no_llm_call(self) -> None:
+        fake = FakeLLM()
+        tree = _make_integration_tree(fake)
+        custom = "Generate <number_of_questions> questions about startups."
+        result = await tree.set_tasks(instructions_template=custom)
+        assert result == custom
+        assert fake.call_count == 0
+
+
+class TestFitIntegration:
+    """Test fit() end-to-end with FakeLLM."""
+
+    @pytest.mark.asyncio
+    async def test_fit_completes(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        nodes = []
+        async for node in tree.fit(X, y):
+            nodes.append(node)
+        assert len(nodes) > 0
+        assert tree.get_root_id() is not None
+        root = tree.get_node(0)
+        assert root is not None
+
+    @pytest.mark.asyncio
+    async def test_fit_produces_correct_class_distribution(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        root = tree.get_node(0)
+        assert root is not None
+        dist = root.class_distribution
+        assert dist["successful"] == 3
+        assert dist["failed"] == 3
+
+    @pytest.mark.asyncio
+    async def test_fit_at_depth_1_call_count(self, tmp_path: Any) -> None:
+        """At max_depth=1, root is the only non-leaf that generates questions."""
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path, max_depth=1)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        # Calls: 1 generate_questions + (2 questions × 6 samples) answers = 13
+        # But actual count depends on whether splits are valid.
+        # At minimum: 1 (generate) + 12 (answers for 2 questions × 6 samples)
+        assert fake.call_count >= 13
+
+    @pytest.mark.asyncio
+    async def test_leaf_nodes_have_no_question(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        for node in tree._nodes.values():
+            if node.is_leaf:
+                assert node.question is None
+
+    @pytest.mark.asyncio
+    async def test_fit_generates_questions_at_nodes(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        df_questions = tree.get_questions()
+        assert df_questions is not None
+        assert len(df_questions) >= 2  # At least root generated 2 questions
+
+
+class TestPredictIntegration:
+    """Test predict() after fit with FakeLLM."""
+
+    @pytest.mark.asyncio
+    async def test_predict_returns_results(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        # Predict on 2 samples
+        test_samples = X.iloc[:2]
+        results = []
+        async for record in tree.predict(test_samples):
+            results.append(record)
+        assert len(results) > 0
+
+    @pytest.mark.asyncio
+    async def test_predict_reaches_leaf(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        test_samples = X.iloc[:1]
+        results = []
+        async for record in tree.predict(test_samples):
+            results.append(record)
+        # Last record for a sample should be "No Question" (reached leaf)
+        leaf_records = [r for r in results if r[1] == "No Question"]
+        assert len(leaf_records) == 1
+
+
+class TestDeterminism:
+    """Test that identical inputs produce identical trees."""
+
+    @pytest.mark.asyncio
+    async def test_same_inputs_same_tree(self, tmp_path: Any) -> None:
+        trees = []
+        for i in range(2):
+            fake = FakeLLM(questions_per_call=2)
+            tree = _make_integration_tree(fake, tmp_path=tmp_path / f"run_{i}")
+            await tree.set_tasks(
+                instructions_template="Generate <number_of_questions> questions."
+            )
+            X, y = _tiny_dataset()
+            async for _ in tree.fit(X, y):
+                pass
+            trees.append(tree)
+        assert len(trees[0]._nodes) == len(trees[1]._nodes)
+        assert set(trees[0]._nodes.keys()) == set(trees[1]._nodes.keys())
+
+
+class TestTimingInstrumentation:
+    """Test that timing stats accumulate during fit."""
+
+    @pytest.mark.asyncio
+    async def test_timing_records_calls(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        summary = tree.timing.summary()
+        assert summary["generate_questions"]["count"] >= 1
+        assert summary["generate_questions"]["total_s"] > 0
+        assert summary["answer_question"]["count"] >= 1
+        assert summary["answer_question_for_row"]["count"] >= 1
+        # answer_question_for_row count should be >= answer_question count
+        assert (
+            summary["answer_question_for_row"]["count"]
+            >= summary["answer_question"]["count"]
+        )
+
+
+class TestAnswerCache:
+    """Test persistent answer cache."""
+
+    def test_cache_roundtrip(self, tmp_path: Any) -> None:
+        from think_reason_learn.gptree._cache import AnswerCache
+
+        cache = AnswerCache(tmp_path / "test.db")
+        assert cache.get("Q1", "Sample1", 0.0, "gemini") is None
+        assert cache.misses == 1
+        cache.put("Q1", "Sample1", 0.0, "gemini", "Yes")
+        assert cache.get("Q1", "Sample1", 0.0, "gemini") == "Yes"
+        assert cache.hits == 1
+        assert len(cache) == 1
+        cache.close()
+
+    def test_different_temps_different_keys(self, tmp_path: Any) -> None:
+        from think_reason_learn.gptree._cache import AnswerCache
+
+        cache = AnswerCache(tmp_path / "test.db")
+        cache.put("Q1", "S1", 0.0, "gemini", "Yes")
+        cache.put("Q1", "S1", 1.0, "gemini", "No")
+        assert cache.get("Q1", "S1", 0.0, "gemini") == "Yes"
+        assert cache.get("Q1", "S1", 1.0, "gemini") == "No"
+        cache.close()
+
+    def test_different_models_different_keys(self, tmp_path: Any) -> None:
+        from think_reason_learn.gptree._cache import AnswerCache
+
+        cache = AnswerCache(tmp_path / "test.db")
+        cache.put("Q1", "S1", 0.0, "gemini-flash", "Yes")
+        cache.put("Q1", "S1", 0.0, "gpt-4o", "No")
+        assert cache.get("Q1", "S1", 0.0, "gemini-flash") == "Yes"
+        assert cache.get("Q1", "S1", 0.0, "gpt-4o") == "No"
+        cache.close()
+
+    @pytest.mark.asyncio
+    async def test_cache_enabled_during_fit(self, tmp_path: Any) -> None:
+        """Fit with cache enabled populates the cache."""
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path, use_answer_cache=True)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+        assert tree._answer_cache is not None
+        assert len(tree._answer_cache) > 0
+        # All entries were misses on first run
+        assert tree._answer_cache.misses > 0
+        assert tree._answer_cache.hits == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_disabled_by_default(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        assert tree._answer_cache is None
+
+
+class TestSaveLoadIntegration:
+    """Test save/load round-trip with FakeLLM-built tree."""
+
+    @pytest.mark.asyncio
+    async def test_save_load_preserves_structure(self, tmp_path: Any) -> None:
+        fake = FakeLLM(questions_per_call=2)
+        tree = _make_integration_tree(fake, tmp_path=tmp_path)
+        await tree.set_tasks(
+            instructions_template="Generate <number_of_questions> questions."
+        )
+        X, y = _tiny_dataset()
+        async for _ in tree.fit(X, y):
+            pass
+
+        original_nodes = len(tree._nodes)
+        original_root_dist = tree.get_node(0).class_distribution  # type: ignore
+
+        # Save and reload
+        tree.save()
+        loaded = GPTree.load(tree.save_path / tree.name)
+
+        assert len(loaded._nodes) == original_nodes
+        assert loaded.get_node(0).class_distribution == original_root_dist  # type: ignore

--- a/think_reason_learn/gptree/__init__.py
+++ b/think_reason_learn/gptree/__init__.py
@@ -4,7 +4,7 @@ Each node uses language models to generate contextual questions and evaluate
 answers, enabling adaptive tree construction for classification tasks.
 """
 
-from ._gptree import GPTree, Node, NodeQuestion
+from ._gptree import GPTree, Node, NodeQuestion, TimingStats
 from ._types import QuestionType, Criterion
 
-__all__ = ["GPTree", "Node", "NodeQuestion", "QuestionType", "Criterion"]
+__all__ = ["GPTree", "Node", "NodeQuestion", "TimingStats", "QuestionType", "Criterion"]

--- a/think_reason_learn/gptree/_cache.py
+++ b/think_reason_learn/gptree/_cache.py
@@ -1,0 +1,77 @@
+"""Persistent answer cache for GPTree.
+
+Stores (question, sample, temperature, model) → answer mappings in SQLite
+so that re-runs, resumed training, and development iteration avoid
+redundant LLM calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import datetime
+from pathlib import Path
+
+
+class AnswerCache:
+    """SQLite-backed cache for ``_answer_question_for_row`` responses.
+
+    Args:
+        db_path: Path to the SQLite database file. Parent directories
+            are created automatically.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS cache "
+            "(key TEXT PRIMARY KEY, answer TEXT, created_at TEXT)"
+        )
+        self._conn.commit()
+        self.hits: int = 0
+        self.misses: int = 0
+
+    @staticmethod
+    def _make_key(question: str, sample: str, temperature: float, model: str) -> str:
+        payload = f"{question}\x00{sample}\x00{temperature}\x00{model}"
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def get(
+        self, question: str, sample: str, temperature: float, model: str
+    ) -> str | None:
+        """Look up a cached answer. Returns ``None`` on miss."""
+        key = self._make_key(question, sample, temperature, model)
+        row = self._conn.execute(
+            "SELECT answer FROM cache WHERE key = ?", (key,)
+        ).fetchone()
+        if row is not None:
+            self.hits += 1
+            return row[0]
+        self.misses += 1
+        return None
+
+    def put(
+        self,
+        question: str,
+        sample: str,
+        temperature: float,
+        model: str,
+        answer: str,
+    ) -> None:
+        """Store an answer in the cache."""
+        key = self._make_key(question, sample, temperature, model)
+        self._conn.execute(
+            "INSERT OR REPLACE INTO cache (key, answer, created_at) VALUES (?, ?, ?)",
+            (key, answer, datetime.datetime.now().isoformat()),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    def __len__(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) FROM cache").fetchone()
+        return row[0] if row else 0

--- a/think_reason_learn/gptree/_gptree.py
+++ b/think_reason_learn/gptree/_gptree.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 from os import PathLike
 import asyncio
+import time
 from typing import List, Dict, Literal, Sequence, cast, Type, Tuple
 from typing import Set, Any, AsyncGenerator
 import logging
@@ -30,11 +31,46 @@ from ._types import QuestionType, Criterion
 from ._prompts import INSTRUCTIONS_FOR_GENERATING_QUESTION_GEN_INSTRUCTIONS
 from ._prompts import num_questions_tag, QUESTION_ANSWER_INSTRUCTIONS
 from ._prompts import CUMULATIVE_MEMORY_INSTRUCTIONS
+from ._cache import AnswerCache
 
 
 logger = logging.getLogger(__name__)
 
 IndexArray = npt.NDArray[np.intp]
+
+
+@dataclass
+class TimingStats:
+    """Accumulates wall-clock timing for GPTree operations."""
+
+    generate_questions_total_s: float = 0.0
+    generate_questions_count: int = 0
+    answer_question_total_s: float = 0.0
+    answer_question_count: int = 0
+    answer_question_for_row_total_s: float = 0.0
+    answer_question_for_row_count: int = 0
+
+    def _record(self, method: str, elapsed: float) -> None:
+        setattr(self, f"{method}_total_s", getattr(self, f"{method}_total_s") + elapsed)
+        setattr(self, f"{method}_count", getattr(self, f"{method}_count") + 1)
+
+    def summary(self) -> Dict[str, Dict[str, float]]:
+        """Return timing summary as a dict of {method: {total_s, count, avg_s}}."""
+        result: Dict[str, Dict[str, float]] = {}
+        _methods = (
+            "generate_questions",
+            "answer_question",
+            "answer_question_for_row",
+        )
+        for method in _methods:
+            total = getattr(self, f"{method}_total_s")
+            count = getattr(self, f"{method}_count")
+            result[method] = {
+                "total_s": total,
+                "count": count,
+                "avg_s": total / count if count > 0 else 0.0,
+            }
+        return result
 
 
 @dataclass(slots=True)
@@ -234,12 +270,16 @@ class GPTree:
         class_weight: Dict[str, float] | Literal["balanced"] | None = None,
         decision_threshold: float | None = None,
         use_critic: bool = False,
+        use_answer_cache: bool = False,
         save_path: str | PathLike[str] | None = None,
         name: str | None = None,
         random_state: int | None = None,
+        _llm: Any = None,
     ):
         locals_dict = deepcopy(locals())
         del locals_dict["self"]
+        locals_dict.pop("_llm", None)
+        locals_dict.pop("use_answer_cache", None)
         self._verify_input_data(**locals_dict)
 
         self.name: str = self._get_name(name)
@@ -269,6 +309,7 @@ class GPTree:
         self.random_state = random_state
 
         self._token_counter: TokenCounter = TokenCounter()
+        self._timing: TimingStats = TimingStats()
         self._class_weights: Dict[str, float] | None = None
 
         self._classes: List[str] | None = None
@@ -284,7 +325,15 @@ class GPTree:
 
         self._frontier: List[BuildTask] = []  # Frontier for resumable training
 
+        self._llm_instance: Any = _llm if _llm is not None else llm
         self._llm_semaphore = asyncio.Semaphore(llm_semaphore_limit)
+
+        # Persistent answer cache (opt-in)
+        self.use_answer_cache = use_answer_cache
+        self._answer_cache: AnswerCache | None = None
+        if use_answer_cache:
+            cache_path = self.save_path / self.name / "answer_cache.db"
+            self._answer_cache = AnswerCache(cache_path)
 
     def _verify_input_data(self, **kwargs: Any) -> None:
         """Verify the input data."""
@@ -454,6 +503,11 @@ class GPTree:
     def token_usage(self) -> TokenCounter:
         """Get the token counter for the GPTree."""
         return self._token_counter
+
+    @property
+    def timing(self) -> TimingStats:
+        """Get the timing stats for GPTree operations."""
+        return self._timing
 
     @property
     def question_gen_instructions_template(self) -> str | None:
@@ -734,7 +788,7 @@ class GPTree:
                 return instructions_template
 
         async with self._llm_semaphore:
-            response = await llm.respond(
+            response = await self._llm_instance.respond(
                 query=f"Build a decision tree for:\n{task_description}",
                 llm_priority=self.qgen_llmc,
                 response_format=str,
@@ -796,6 +850,7 @@ class GPTree:
         cumulative_memory: str | None,
         node_depth: int,
     ) -> Questions:
+        _t0 = time.perf_counter()
         if self._X is None or self._y is None:
             raise ValueError("X and y must be set")
         if sample_indices.shape[0] == 0:
@@ -863,7 +918,7 @@ class GPTree:
         query += f"Cumulative advice from previous nodes: {cumulative_memory}"
 
         async with self._llm_semaphore:
-            response = await llm.respond(
+            response = await self._llm_instance.respond(
                 query=query,
                 llm_priority=self.qgen_llmc,
                 response_format=Questions,
@@ -890,6 +945,7 @@ class GPTree:
             # TODO: Implement critic
             pass
 
+        self._timing._record("generate_questions", time.perf_counter() - _t0)
         return questions
 
     def _make_answer_model(self, choices: List[str]) -> Type[Answer]:
@@ -904,11 +960,32 @@ class GPTree:
         question: NodeQuestion,
         token_counter: TokenCounter,
     ) -> Tuple[Any, Answer] | None:
+        _t0 = time.perf_counter()
         AnswerModel = self._make_answer_model(question.choices)
+
+        # Check persistent cache first
+        if self._answer_cache is not None:
+            first_llmc = self.qanswer_llmc[0] if self.qanswer_llmc else None
+            model_name = (
+                getattr(first_llmc, "model", "unknown")
+                if first_llmc is not None
+                else "unknown"
+            )
+            cached = self._answer_cache.get(
+                question=question.value,
+                sample=sample,
+                temperature=self.qanswer_temperature,
+                model=str(model_name),
+            )
+            if cached is not None:
+                self._timing._record(
+                    "answer_question_for_row", time.perf_counter() - _t0
+                )
+                return idx, AnswerModel(answer=cached)
 
         try:
             async with self._llm_semaphore:
-                response = await llm.respond(
+                response = await self._llm_instance.respond(
                     llm_priority=self.qanswer_llmc,
                     query=f"Query: {question.value}\n\nSample: {sample}",
                     instructions=QUESTION_ANSWER_INSTRUCTIONS,
@@ -933,6 +1010,24 @@ class GPTree:
                     "Could not track confidence of answer. "
                     f"Answered question: '{question.value}' for sample: {sample}"
                 )
+
+            # Write to persistent cache
+            if self._answer_cache is not None:
+                first_llmc = self.qanswer_llmc[0] if self.qanswer_llmc else None
+                model_name = (
+                    getattr(first_llmc, "model", "unknown")
+                    if first_llmc is not None
+                    else "unknown"
+                )
+                self._answer_cache.put(
+                    question=question.value,
+                    sample=sample,
+                    temperature=self.qanswer_temperature,
+                    model=str(model_name),
+                    answer=response.response.answer,
+                )
+
+            self._timing._record("answer_question_for_row", time.perf_counter() - _t0)
             return idx, response.response
 
         except Exception as _:
@@ -947,6 +1042,7 @@ class GPTree:
         sample_indices: IndexArray,
     ) -> None:
         """Answer a question for a subset of self._X inplace."""
+        _t0 = time.perf_counter()
         if self._X is None or self._y is None:
             raise ValueError("X and y must be set")
 
@@ -1013,6 +1109,7 @@ class GPTree:
                 series_update = pd.Series(answers_buffer, dtype=object)
                 index_update = cast(pd.Index, series_update.index)
                 self._X.loc[index_update, question.df_column] = series_update
+            self._timing._record("answer_question", time.perf_counter() - _t0)
 
     async def _build_tree(
         self,


### PR DESCRIPTION
## Summary
- add GPTree timing instrumentation (TimingStats)
- add optional persistent GPTree answer cache (AnswerCache)
- extend FakeLLM dispatch to cover GPTree call sites
- add GPTree/FakeLLM test coverage for testability additions

## Notes
- branch salvages commit 62fe340ce onto current main
- isolated from unrelated local working-tree changes