### PR TITLE
fix: configure pyright for local venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ build-backend = "poetry.core.masonry.api"
 line-length = 88
 target-version = "py313" 
 
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+
 [tool.ruff.lint]
 select = ["E", "F", "D"]   # E/F for pyflakes + pycodestyle, D for docstrings
 ignore = ["D101"]


### PR DESCRIPTION
## summary
add pyright virtualenv settings in pyproject so the default type-check command resolves dependencies from the repo's .venv.

## verification
- .venv/bin/pyright
- poetry run pyright
- .venv/bin/ruff check .
- .venv/bin/pytest -q