### PR TITLE
Fix/sklearn 18 lrcv compat

### DIFF
--- a/tests/test_rrf.py
+++ b/tests/test_rrf.py
@@ -9,6 +9,7 @@ import pytest
 import pandas as pd
 
 from think_reason_learn.rrf import RRF, QuestionExclusion
+from think_reason_learn.rrf import _rrf as rrf_mod
 from think_reason_learn.rrf._rrf import Questions, Answer
 from think_reason_learn.core.llms import LLMChoice, OpenAIChoice
 from think_reason_learn.core.exceptions import DataError
@@ -2556,3 +2557,51 @@ class TestElasticNetAggregation:
         assert loaded._aggregation_intercept == rrf._aggregation_intercept
         assert loaded._aggregation_threshold == rrf._aggregation_threshold
         assert loaded._aggregation_feature_order == rrf._aggregation_feature_order
+
+
+class TestElasticNetSklearnCompat:
+    """LogisticRegressionCV kwargs must track the sklearn 1.8 API changes.
+
+    sklearn 1.8 deprecated ``penalty`` (removal in 1.10; elastic-net is
+    requested via ``l1_ratios`` alone) and warns on fit unless
+    ``use_legacy_attributes`` is set explicitly.
+    """
+
+    def _captured_lrcv_kwargs(
+        self, monkeypatch: pytest.MonkeyPatch, pre_18: bool
+    ) -> dict[str, Any]:
+        captured: dict[str, Any] = {}
+
+        class _StubLRCV:
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+                self.coef_ = np.array([[1.0, 0.0, -1.0]])
+                self.intercept_ = np.array([0.0])
+
+            def fit(self, x: Any, y: Any) -> _StubLRCV:
+                return self
+
+            def predict_proba(self, x: Any) -> np.ndarray:
+                return np.tile([0.4, 0.6], (len(x), 1))
+
+        monkeypatch.setattr(rrf_mod, "LogisticRegressionCV", _StubLRCV)
+        monkeypatch.setattr(rrf_mod, "_SKLEARN_PRE_1_8", pre_18, raising=False)
+        rrf, _ = _enet_rrf()
+        rrf._tune_aggregation()
+        return captured
+
+    def test_pre_18_passes_elasticnet_penalty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        kwargs = self._captured_lrcv_kwargs(monkeypatch, pre_18=True)
+        assert kwargs["penalty"] == "elasticnet"
+        assert kwargs["l1_ratios"] == [0.1, 0.5]
+        assert "use_legacy_attributes" not in kwargs
+
+    def test_sklearn_18_omits_deprecated_penalty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        kwargs = self._captured_lrcv_kwargs(monkeypatch, pre_18=False)
+        assert "penalty" not in kwargs
+        assert kwargs["l1_ratios"] == [0.1, 0.5]
+        assert kwargs["use_legacy_attributes"] is False

--- a/think_reason_learn/rrf/_rrf.py
+++ b/think_reason_learn/rrf/_rrf.py
@@ -35,6 +35,7 @@ import numpy.typing as npt
 import orjson
 import pandas as pd
 from pydantic import BaseModel, Field
+from sklearn import __version__ as _sklearn_version
 from sklearn.linear_model import LogisticRegressionCV
 
 from think_reason_learn.core.exceptions import CorruptionError, DataError, LLMError
@@ -51,6 +52,10 @@ from ._prompts import (
 from ._types import AnsSimilarityFunc, EmbeddingModel
 
 logger = logging.getLogger(__name__)
+
+# sklearn 1.8 deprecated LogisticRegressionCV's `penalty` (removal in 1.10):
+# elastic-net is now requested via `l1_ratios` alone.
+_SKLEARN_PRE_1_8 = tuple(int(p) for p in _sklearn_version.split(".")[:2]) < (1, 8)
 
 
 class Questions(BaseModel):
@@ -1566,18 +1571,25 @@ class RRF:
             )
             return
 
-        model = LogisticRegressionCV(
-            penalty="elasticnet",
-            solver="saga",
-            Cs=list(self.elasticnet_cs),  # type: ignore[arg-type]
-            l1_ratios=list(self.elasticnet_l1_ratios),
-            cv=self.elasticnet_cv,
-            scoring="roc_auc",
-            max_iter=5000,
-            random_state=self.random_state,
-            n_jobs=1,
-            refit=True,
-        )
+        lrcv_kwargs: Dict[str, Any] = {
+            "solver": "saga",
+            "Cs": list(self.elasticnet_cs),
+            "l1_ratios": list(self.elasticnet_l1_ratios),
+            "cv": self.elasticnet_cv,
+            "scoring": "roc_auc",
+            "max_iter": 5000,
+            "random_state": self.random_state,
+            "n_jobs": 1,
+            "refit": True,
+        }
+        if _SKLEARN_PRE_1_8:
+            # Pre-1.8, l1_ratios is only applied when penalty="elasticnet".
+            lrcv_kwargs["penalty"] = "elasticnet"
+        else:
+            # Opt in to the simplified fitted attributes to silence the 1.8
+            # FutureWarning; only coef_/intercept_/predict_proba are read here.
+            lrcv_kwargs["use_legacy_attributes"] = False
+        model = LogisticRegressionCV(**lrcv_kwargs)
         model.fit(x, y_true)
         proba = model.predict_proba(x)[:, 1]
 


### PR DESCRIPTION
## Summary

scikit-learn 1.8 changed `LogisticRegressionCV` in two ways that break the RRF elastic-net aggregation (added in #74) for anyone on sklearn ≥ 1.8:

- `penalty` is deprecated (removal planned for 1.10) — elastic-net is now requested via `l1_ratios` alone — and every `fit()` emits `FutureWarning`s unless `use_legacy_attributes` is set explicitly.
- The `l1_ratios` default became the sentinel string `"warn"`. sklearn ships no type annotations, so pyright infers the parameter as `str` and reports at `_rrf.py:1573`: `Argument of type "list[float]" cannot be assigned to parameter "l1_ratios" of type "str"`. (`poetry.lock` pins 1.7.2, but `pyproject.toml` allows `<2.0.0`, so fresh pip installs already get 1.8+.)

This PR builds the `LogisticRegressionCV` kwargs per installed version:

- **sklearn < 1.8** — unchanged: passes `penalty="elasticnet"` (required there for `l1_ratios` to take effect). No behavior change on the locked 1.7.2.
- **sklearn ≥ 1.8** — omits the deprecated `penalty` and sets `use_legacy_attributes=False`; the aggregation only reads `coef_` / `intercept_` / `predict_proba`, which are unaffected by the attribute simplification.

### Testing

- New `TestElasticNetSklearnCompat` pins the expected kwargs for both version branches. The first commit adds the failing test, the second makes it pass — squash-merge suggested.
- Verified locally on Python 3.13.14 + sklearn **1.9.0**: 105/105 tests in `tests/test_rrf.py` pass with zero deprecation warnings (previously 8 `FutureWarning`s per run), and pyright on `_rrf.py` goes from exactly the error above to 0 errors. CI covers the locked 1.7.2 path.

## Type of change

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [x] test
- [ ] chore

## Checklist

- [x] Tests added/updated
- [x] Lint and type-check pass
- [ ] Docs updated (if needed) — not needed, no public API change

## Related issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)     