### PR TITLE
feat(llms): add local-Ollama / OpenAI-compat chat-completions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ async def main():
 asyncio.run(main())
 ```
 
+### Using a local model (Ollama, vLLM)
+
+The `openai` provider works against any OpenAI-compatible server. Point it at
+your local endpoint and pick your local model — no code changes needed:
+
+```bash
+export OPENAI_BASE_URL=http://localhost:11434/v1   # Ollama's default port
+export OPENAI_API_KEY=ollama                       # any non-empty value works locally
+```
+
+```python
+from think_reason_learn.core.llms import OpenAIChoice
+
+qgen_llmc = [OpenAIChoice(model="qwen3:8b")]  # any model served locally
+```
+
+When `OPENAI_BASE_URL` is set, TRL routes requests through
+`/v1/chat/completions` with token logprobs (which Reasoned Rule Mining
+depends on) instead of `/v1/responses`, which local servers don't implement.
+Set `OPENAI_ENDPOINT_STYLE` to `responses` or `chat_completions` to override
+the auto-detection.
+
 For more examples and detailed usage, see the [examples notebooks](https://github.com/Vela-Research/think-reason-learn/tree/main/examples).
 
 ## Contributing

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -80,4 +80,32 @@ GPTree
    for pred in predictions:
        print(pred)
 
+Using a local model (Ollama, vLLM, or any OpenAI-compatible server)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``openai`` provider works against any server that implements the OpenAI
+chat-completions API. Point it at your local endpoint and pick your local
+model — no code changes needed:
+
+.. code-block:: bash
+
+   export OPENAI_BASE_URL=http://localhost:11434/v1   # Ollama's default port
+   export OPENAI_API_KEY=ollama                       # any non-empty value works locally
+
+.. code-block:: python
+
+   from think_reason_learn.core.llms import OpenAIChoice
+
+   qgen_llmc = [OpenAIChoice(model="qwen3:8b")]  # any model served locally
+
+When ``OPENAI_BASE_URL`` is set, requests are routed through
+``/v1/chat/completions`` with token logprobs enabled (Reasoned Rule Mining
+depends on ``response.logprobs``) instead of the ``/v1/responses`` endpoint,
+which local servers generally do not implement. The routing is controlled by
+the ``endpoint_style`` parameter of the OpenAI provider
+(``"responses"`` or ``"chat_completions"``) and auto-detected from the base
+URL when unset. Override it with the ``OPENAI_ENDPOINT_STYLE`` environment
+variable — for example, ``OPENAI_ENDPOINT_STYLE=chat_completions`` also gets
+token logprobs from OpenAI's hosted API.
+
 For more examples and comprehensive use cases, visit the `examples directory <https://github.com/vela-research/think-reason-learn/tree/main/examples>`_ on our GitHub repository.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
+
+import pytest
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _ensure_main_thread_event_loop():
+    """Guarantee a current event loop exists in the main thread for every test.
+
+    pytest-asyncio 1.x closes and clears the current loop after each
+    ``@pytest.mark.asyncio`` test, leaving subsequent synchronous tests without
+    one. Libraries like ``grpc.aio`` (used by ``xai_sdk``) call
+    ``asyncio.get_event_loop()`` during client construction and error out with
+    ``RuntimeError: There is no current event loop`` when it returns nothing.
+
+    This autouse fixture restores a current loop before every test if none is
+    set. Cheap, side-effect-free, keeps CI ordering-independent.
+    """
+    try:
+        asyncio.get_event_loop_policy().get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    yield

--- a/tests/test_openai_chat_llm.py
+++ b/tests/test_openai_chat_llm.py
@@ -4,10 +4,45 @@ All tests run offline: the OpenAI SDK client methods are replaced with mocks,
 so no Ollama or OpenAI account is needed.
 """
 
+import asyncio
+import math
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
+from pydantic import BaseModel
 
 from think_reason_learn.core._singleton import SingletonMeta
 from think_reason_learn.core.llms._openai.ask import OpenAILLM, get_openai_llm
+
+
+class _Verdict(BaseModel):
+    answer: str
+    confident: bool
+
+
+def _fake_completion(content=None, parsed=None, logprob_pairs=None, total_tokens=42):
+    """Build a chat-completion response shape (SDK objects are attr-access only)."""
+    logprobs = None
+    if logprob_pairs is not None:
+        logprobs = SimpleNamespace(
+            content=[SimpleNamespace(token=t, logprob=lp) for t, lp in logprob_pairs]
+        )
+    choice = SimpleNamespace(
+        message=SimpleNamespace(content=content, parsed=parsed),
+        logprobs=logprobs,
+    )
+    return SimpleNamespace(
+        choices=[choice], usage=SimpleNamespace(total_tokens=total_tokens)
+    )
+
+
+def _chat_llm():
+    """OpenAILLM pointed at a local server, with fully mocked SDK clients."""
+    llm = OpenAILLM(api_key="ollama", base_url="http://localhost:11434/v1")
+    llm.client = MagicMock()
+    llm.aclient = MagicMock()
+    return llm
 
 
 @pytest.fixture(autouse=True)
@@ -54,3 +89,134 @@ def test_get_openai_llm_defaults_api_key_for_local_servers():
 
 def test_get_openai_llm_still_none_without_key_or_base_url():
     assert get_openai_llm("") is None
+
+
+def test_chat_string_response_preserves_logprobs_sync():
+    llm = _chat_llm()
+    pairs = [("Hello", -0.05), (" world", -0.2)]
+    llm.client.chat.completions.create = MagicMock(
+        return_value=_fake_completion(content="Hello world", logprob_pairs=pairs)
+    )
+
+    result = llm.respond_sync(model="qwen3:8b", query="Say hello", raise_=True)
+
+    assert result is not None
+    assert result.response == "Hello world"
+    assert result.logprobs == pairs
+    assert result.total_tokens == 42
+    assert result.provider_model.model == "qwen3:8b"
+    call_kwargs = llm.client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["logprobs"] is True
+    assert call_kwargs["top_logprobs"] == 5
+    assert call_kwargs["messages"] == [{"role": "user", "content": "Say hello"}]
+    llm.client.responses.create.assert_not_called()
+    llm.client.responses.parse.assert_not_called()
+
+
+def test_chat_instructions_become_system_message_sync():
+    llm = _chat_llm()
+    llm.client.chat.completions.create = MagicMock(
+        return_value=_fake_completion(content="ok", logprob_pairs=[])
+    )
+
+    llm.respond_sync(model="qwen3:8b", query="Q", instructions="Be terse", raise_=True)
+
+    messages = llm.client.chat.completions.create.call_args.kwargs["messages"]
+    assert messages == [
+        {"role": "system", "content": "Be terse"},
+        {"role": "user", "content": "Q"},
+    ]
+
+
+def test_chat_structured_output_uses_parse_sync():
+    llm = _chat_llm()
+    parsed = _Verdict(answer="yes", confident=True)
+    llm.client.chat.completions.parse = MagicMock(
+        return_value=_fake_completion(parsed=parsed, logprob_pairs=[("yes", -0.1)])
+    )
+
+    result = llm.respond_sync(
+        model="qwen3:8b", query="Q", response_format=_Verdict, raise_=True
+    )
+
+    assert result is not None
+    assert result.response is parsed
+    assert result.logprobs == [("yes", -0.1)]
+    call_kwargs = llm.client.chat.completions.parse.call_args.kwargs
+    assert call_kwargs["response_format"] is _Verdict
+    assert call_kwargs["logprobs"] is True
+
+
+def test_chat_missing_logprobs_yields_empty_list_sync():
+    llm = _chat_llm()
+    llm.client.chat.completions.create = MagicMock(
+        return_value=_fake_completion(content="hi", logprob_pairs=None)
+    )
+
+    result = llm.respond_sync(model="qwen3:8b", query="Q", raise_=True)
+
+    assert result is not None
+    assert result.logprobs == []
+
+
+def test_chat_temperature_zero_is_preserved_sync():
+    llm = _chat_llm()
+    llm.client.chat.completions.create = MagicMock(
+        return_value=_fake_completion(content="hi", logprob_pairs=[])
+    )
+
+    llm.respond_sync(model="qwen3:8b", query="Q", temperature=0.0, raise_=True)
+
+    assert llm.client.chat.completions.create.call_args.kwargs["temperature"] == 0.0
+
+
+def test_chat_logprobs_drive_average_confidence():
+    llm = _chat_llm()
+    pairs = [("a", -0.1), ("b", -0.3)]
+    llm.client.chat.completions.create = MagicMock(
+        return_value=_fake_completion(content="ab", logprob_pairs=pairs)
+    )
+
+    result = llm.respond_sync(model="qwen3:8b", query="Q", raise_=True)
+
+    assert result is not None
+    assert result.average_confidence == pytest.approx(math.exp(-0.2))
+
+
+def test_chat_error_returns_none_unless_raise():
+    llm = _chat_llm()
+    llm.client.chat.completions.create = MagicMock(side_effect=RuntimeError("boom"))
+
+    assert llm.respond_sync(model="qwen3:8b", query="Q") is None
+    with pytest.raises(RuntimeError):
+        llm.respond_sync(model="qwen3:8b", query="Q", raise_=True)
+
+
+def test_chat_string_response_async():
+    llm = _chat_llm()
+    pairs = [("4", -0.01)]
+    llm.aclient.chat.completions.create = AsyncMock(
+        return_value=_fake_completion(content="4", logprob_pairs=pairs)
+    )
+
+    result = asyncio.run(llm.respond(model="qwen3:8b", query="2+2?", raise_=True))
+
+    assert result is not None
+    assert result.response == "4"
+    assert result.logprobs == pairs
+
+
+def test_chat_structured_output_async():
+    llm = _chat_llm()
+    parsed = _Verdict(answer="no", confident=False)
+    llm.aclient.chat.completions.parse = AsyncMock(
+        return_value=_fake_completion(parsed=parsed, logprob_pairs=[("no", -0.3)])
+    )
+
+    result = asyncio.run(
+        llm.respond(model="qwen3:8b", query="Q", response_format=_Verdict, raise_=True)
+    )
+
+    assert result is not None
+    assert result.response is parsed
+    assert result.logprobs == [("no", -0.3)]

--- a/tests/test_openai_chat_llm.py
+++ b/tests/test_openai_chat_llm.py
@@ -206,6 +206,48 @@ def test_chat_string_response_async():
     assert result.logprobs == pairs
 
 
+def test_responses_path_still_used_without_base_url():
+    """Backward compat: no base_url means the /v1/responses path, unchanged."""
+    llm = OpenAILLM(api_key="sk-test")
+    llm.client = MagicMock()
+    fake = SimpleNamespace(output_text="cloud", usage=SimpleNamespace(total_tokens=3))
+    llm.client.responses.create = MagicMock(return_value=fake)
+
+    result = llm.respond_sync(model="gpt-5", query="Q", raise_=True)
+
+    assert result is not None
+    assert result.response == "cloud"
+    llm.client.responses.create.assert_called_once()
+    llm.client.chat.completions.create.assert_not_called()
+
+
+def test_dict_llm_priority_record_routes_to_chat_completions():
+    """Dict provider records (the GPTree trap) are normalized by LLM and
+    reach the chat-completions path intact."""
+    from think_reason_learn.core.llms._ask import LLM
+
+    trl_llm = LLM()
+    orig_openai = trl_llm.openai_llm
+    try:
+        chat_llm = _chat_llm()
+        chat_llm.client.chat.completions.create = MagicMock(
+            return_value=_fake_completion(content="local", logprob_pairs=[("l", -0.4)])
+        )
+        trl_llm.openai_llm = chat_llm
+
+        result = trl_llm.respond_sync(
+            query="Q",
+            llm_priority=[{"provider": "openai", "model": "qwen3:8b"}],
+            response_format=str,
+        )
+
+        assert result.response == "local"
+        assert result.logprobs == [("l", -0.4)]
+        chat_llm.client.chat.completions.create.assert_called_once()
+    finally:
+        trl_llm.openai_llm = orig_openai
+
+
 def test_chat_structured_output_async():
     llm = _chat_llm()
     parsed = _Verdict(answer="no", confident=False)

--- a/tests/test_openai_chat_llm.py
+++ b/tests/test_openai_chat_llm.py
@@ -1,0 +1,56 @@
+"""Tests for OpenAILLM chat-completions (local / OpenAI-compatible server) support.
+
+All tests run offline: the OpenAI SDK client methods are replaced with mocks,
+so no Ollama or OpenAI account is needed.
+"""
+
+import pytest
+
+from think_reason_learn.core._singleton import SingletonMeta
+from think_reason_learn.core.llms._openai.ask import OpenAILLM, get_openai_llm
+
+
+@pytest.fixture(autouse=True)
+def _isolate_openai_singleton(monkeypatch):
+    """OpenAILLM is a singleton; reset it and scrub env so tests are hermetic."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    SingletonMeta._instances.pop(OpenAILLM, None)
+    yield
+    SingletonMeta._instances.pop(OpenAILLM, None)
+
+
+def test_defaults_to_responses_endpoint_without_base_url():
+    llm = OpenAILLM(api_key="sk-test")
+    assert llm.endpoint_style == "responses"
+
+
+def test_auto_detects_chat_completions_when_base_url_set():
+    llm = OpenAILLM(api_key="ollama", base_url="http://localhost:11434/v1")
+    assert llm.endpoint_style == "chat_completions"
+
+
+def test_explicit_endpoint_style_beats_auto_detection():
+    llm = OpenAILLM(
+        api_key="sk-test",
+        base_url="http://localhost:8000/v1",
+        endpoint_style="responses",
+    )
+    assert llm.endpoint_style == "responses"
+
+
+def test_base_url_env_var_enables_chat_completions(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    llm = OpenAILLM(api_key="ollama")
+    assert llm.endpoint_style == "chat_completions"
+    assert "11434" in str(llm.client.base_url)
+
+
+def test_get_openai_llm_defaults_api_key_for_local_servers():
+    llm = get_openai_llm("", base_url="http://localhost:11434/v1")
+    assert llm is not None
+    assert llm.client.api_key == "ollama"
+
+
+def test_get_openai_llm_still_none_without_key_or_base_url():
+    assert get_openai_llm("") is None

--- a/tests/test_openai_chat_llm.py
+++ b/tests/test_openai_chat_llm.py
@@ -7,6 +7,7 @@ so no Ollama or OpenAI account is needed.
 import asyncio
 import math
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -109,8 +110,9 @@ def test_chat_string_response_preserves_logprobs_sync():
     assert call_kwargs["logprobs"] is True
     assert call_kwargs["top_logprobs"] == 5
     assert call_kwargs["messages"] == [{"role": "user", "content": "Say hello"}]
-    llm.client.responses.create.assert_not_called()
-    llm.client.responses.parse.assert_not_called()
+    mock_client = cast(MagicMock, llm.client)
+    mock_client.responses.create.assert_not_called()
+    mock_client.responses.parse.assert_not_called()
 
 
 def test_chat_instructions_become_system_message_sync():

--- a/tests/test_openai_chat_llm.py
+++ b/tests/test_openai_chat_llm.py
@@ -4,7 +4,6 @@ All tests run offline: the OpenAI SDK client methods are replaced with mocks,
 so no Ollama or OpenAI account is needed.
 """
 
-import asyncio
 import math
 from types import SimpleNamespace
 from typing import cast
@@ -194,14 +193,15 @@ def test_chat_error_returns_none_unless_raise():
         llm.respond_sync(model="qwen3:8b", query="Q", raise_=True)
 
 
-def test_chat_string_response_async():
+@pytest.mark.asyncio
+async def test_chat_string_response_async():
     llm = _chat_llm()
     pairs = [("4", -0.01)]
     llm.aclient.chat.completions.create = AsyncMock(
         return_value=_fake_completion(content="4", logprob_pairs=pairs)
     )
 
-    result = asyncio.run(llm.respond(model="qwen3:8b", query="2+2?", raise_=True))
+    result = await llm.respond(model="qwen3:8b", query="2+2?", raise_=True)
 
     assert result is not None
     assert result.response == "4"
@@ -250,15 +250,16 @@ def test_dict_llm_priority_record_routes_to_chat_completions():
         trl_llm.openai_llm = orig_openai
 
 
-def test_chat_structured_output_async():
+@pytest.mark.asyncio
+async def test_chat_structured_output_async():
     llm = _chat_llm()
     parsed = _Verdict(answer="no", confident=False)
     llm.aclient.chat.completions.parse = AsyncMock(
         return_value=_fake_completion(parsed=parsed, logprob_pairs=[("no", -0.3)])
     )
 
-    result = asyncio.run(
-        llm.respond(model="qwen3:8b", query="Q", response_format=_Verdict, raise_=True)
+    result = await llm.respond(
+        model="qwen3:8b", query="Q", response_format=_Verdict, raise_=True
     )
 
     assert result is not None

--- a/tests/test_openai_chat_llm.py
+++ b/tests/test_openai_chat_llm.py
@@ -262,3 +262,44 @@ def test_chat_structured_output_async():
     assert result is not None
     assert result.response is parsed
     assert result.logprobs == [("no", -0.3)]
+
+
+def test_settings_read_base_url_and_endpoint_style_from_env(monkeypatch, tmp_path):
+    from think_reason_learn.core._config import Settings
+
+    monkeypatch.chdir(tmp_path)  # keep a developer .env file out of the picture
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("OPENAI_ENDPOINT_STYLE", "chat_completions")
+
+    fresh = Settings()
+
+    assert fresh.OPENAI_BASE_URL == "http://localhost:11434/v1"
+    assert fresh.OPENAI_ENDPOINT_STYLE == "chat_completions"
+
+
+def test_settings_reject_invalid_endpoint_style(monkeypatch, tmp_path):
+    from pydantic import ValidationError
+
+    from think_reason_learn.core._config import Settings
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_ENDPOINT_STYLE", "grpc")
+
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_llm_wires_openai_base_url_from_settings(monkeypatch):
+    from think_reason_learn.core._config import settings
+    from think_reason_learn.core.llms._ask import LLM
+
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "")
+    monkeypatch.setattr(settings, "OPENAI_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setattr(settings, "OPENAI_ENDPOINT_STYLE", "")
+    SingletonMeta._instances.pop(LLM, None)
+    try:
+        trl_llm = LLM()
+        assert trl_llm.openai_llm is not None
+        assert trl_llm.openai_llm.endpoint_style == "chat_completions"
+    finally:
+        SingletonMeta._instances.pop(LLM, None)

--- a/think_reason_learn/core/_config.py
+++ b/think_reason_learn/core/_config.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 from pydantic_settings import SettingsConfigDict
 
@@ -6,6 +8,12 @@ class Settings(BaseSettings):
     """Class to store all the settings of the application."""
 
     OPENAI_API_KEY: str = ""
+    OPENAI_BASE_URL: str = ""
+    """Point the OpenAI provider at an OpenAI-compatible server,
+    e.g. ``http://localhost:11434/v1`` for a local Ollama."""
+    OPENAI_ENDPOINT_STYLE: Literal["", "responses", "chat_completions"] = ""
+    """Force the OpenAI API surface. Empty means auto-detect:
+    ``chat_completions`` when ``OPENAI_BASE_URL`` is set, else ``responses``."""
     GOOGLE_AI_API_KEY: str = ""
     XAI_API_KEY: str = ""
     ANTHROPIC_API_KEY: str = ""

--- a/think_reason_learn/core/llms/__init__.py
+++ b/think_reason_learn/core/llms/__init__.py
@@ -24,6 +24,7 @@ from ._schemas import (
     TokenCounter,
     TokenCount,
 )
+from ._openai.schemas import OpenAIEndpointStyle
 from ._ask import LLM
 
 
@@ -51,6 +52,7 @@ __all__ = [
     "LLMChatModel",
     "LLMProvider",
     "OpenAIChatModel",
+    "OpenAIEndpointStyle",
     "GoogleChatModel",
     "AnthropicChatModel",
     "xAIChatModel",

--- a/think_reason_learn/core/llms/_ask.py
+++ b/think_reason_learn/core/llms/_ask.py
@@ -94,7 +94,10 @@ class LLM(metaclass=SingletonMeta):
             **kwargs: Additional arguments to pass to the LLM. For:
 
                 - OpenAI: ``openai.OpenAI.responses.parse`` or
-                    ``openai.OpenAI.responses.create``.
+                    ``openai.OpenAI.responses.create`` — or the
+                    ``chat.completions`` equivalents when the provider's
+                    ``endpoint_style`` is ``"chat_completions"`` (e.g.
+                    against a local OpenAI-compatible server).
                 - Google: ``google.genai.types.GenerateContentConfig``.
                 - XAI: ``xai_sdk.Client.chat.create``.
                 - Anthropic: ``anthropic.Client.messages.create``.
@@ -211,7 +214,10 @@ class LLM(metaclass=SingletonMeta):
             **kwargs: Additional arguments to pass to the LLM. For:
 
                 - OpenAI: ``openai.OpenAI.responses.parse`` or
-                    ``openai.OpenAI.responses.create``.
+                    ``openai.OpenAI.responses.create`` — or the
+                    ``chat.completions`` equivalents when the provider's
+                    ``endpoint_style`` is ``"chat_completions"`` (e.g.
+                    against a local OpenAI-compatible server).
                 - Google: ``google.genai.types.GenerateContentConfig``.
                 - XAI: ``xai_sdk.Client.chat.create``.
                 - Anthropic: ``anthropic.Client.messages.create``.

--- a/think_reason_learn/core/llms/_ask.py
+++ b/think_reason_learn/core/llms/_ask.py
@@ -27,7 +27,11 @@ class LLM(metaclass=SingletonMeta):
     def __init__(self) -> None:
         self.anthropic_llm = get_anthropic_llm(settings.ANTHROPIC_API_KEY)
         self.google_llm = get_google_llm(settings.GOOGLE_AI_API_KEY)
-        self.openai_llm = get_openai_llm(settings.OPENAI_API_KEY)
+        self.openai_llm = get_openai_llm(
+            settings.OPENAI_API_KEY,
+            base_url=settings.OPENAI_BASE_URL or None,
+            endpoint_style=settings.OPENAI_ENDPOINT_STYLE or None,
+        )
         self.xai_llm = get_xai_llm(settings.XAI_API_KEY)
 
     def _val_llm_priority_and_api_keys(

--- a/think_reason_learn/core/llms/_openai/ask.py
+++ b/think_reason_learn/core/llms/_openai/ask.py
@@ -1,4 +1,4 @@
-from typing import Type, Any, cast, Dict
+from typing import Type, Any, cast, Dict, List, Tuple
 import logging
 import os
 
@@ -30,12 +30,136 @@ class OpenAILLM(metaclass=SingletonMeta):
         )
         self.top_logprobs = top_logprobs
 
-    def _process_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def _process_kwargs(self, kwargs: Dict[str, Any], method: Any) -> Dict[str, Any]:
         return {
             k: v if v else (None if v is None else NOT_GIVEN)
             for k, v in kwargs.items()
-            if k in self.client.responses.parse.__annotations__
+            if k in method.__annotations__
         }
+
+    @staticmethod
+    def _chat_messages(
+        query: str,
+        instructions: str | NotGiven | None,
+        kwargs: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        messages: List[Dict[str, Any]] = list(kwargs.pop("messages", None) or [])
+        if query and (not messages or messages[-1].get("role") != "user"):
+            messages.append({"role": "user", "content": query})
+        if instructions and not any(m.get("role") == "system" for m in messages):
+            messages.insert(0, {"role": "system", "content": instructions})
+        return messages
+
+    @staticmethod
+    def _extract_logprobs(choice: Any) -> List[Tuple[str, float | None]]:
+        logprobs = getattr(choice, "logprobs", None)
+        if logprobs and logprobs.content:
+            return [(t.token, t.logprob) for t in logprobs.content]
+        return []
+
+    def _respond_chat_sync(
+        self,
+        model: OpenAIChatModel,
+        query: str,
+        response_format: Type[T],
+        instructions: str | NotGiven | None,
+        temperature: float | NotGiven | None,
+        raise_: bool,
+        kwargs: Dict[str, Any],
+    ) -> LLMResponse[T] | None:
+        kwargs = self._process_kwargs(kwargs, self.client.chat.completions.create)
+        messages = self._chat_messages(query, instructions, kwargs)
+        kwargs.setdefault("logprobs", True)
+        kwargs.setdefault("top_logprobs", self.top_logprobs)
+
+        try:
+            if issubclass(response_format, BaseModel):
+                completion = self.client.chat.completions.parse(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    response_format=response_format,
+                    **kwargs,
+                )
+                choice = completion.choices[0]
+                response = cast(T, choice.message.parsed)
+            else:
+                completion = self.client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    **kwargs,
+                )
+                choice = completion.choices[0]
+                response = cast(T, choice.message.content or "")
+
+            return LLMResponse(
+                response=response,
+                logprobs=self._extract_logprobs(choice),
+                total_tokens=(
+                    completion.usage.total_tokens if completion.usage else None
+                ),
+                provider_model=OpenAIChoice(model=model),
+            )
+        except Exception as e:
+            logger.warning(
+                f"Error responding with OpenAI (chat.completions): {e}", exc_info=True
+            )
+            if raise_:
+                raise e
+            return None
+
+    async def _respond_chat(
+        self,
+        model: OpenAIChatModel,
+        query: str,
+        response_format: Type[T],
+        instructions: str | NotGiven | None,
+        temperature: float | NotGiven | None,
+        raise_: bool,
+        kwargs: Dict[str, Any],
+    ) -> LLMResponse[T] | None:
+        kwargs = self._process_kwargs(kwargs, self.aclient.chat.completions.create)
+        messages = self._chat_messages(query, instructions, kwargs)
+        kwargs.setdefault("logprobs", True)
+        kwargs.setdefault("top_logprobs", self.top_logprobs)
+
+        try:
+            if issubclass(response_format, BaseModel):
+                completion = await self.aclient.chat.completions.parse(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    response_format=response_format,
+                    **kwargs,
+                )
+                choice = completion.choices[0]
+                response = cast(T, choice.message.parsed)
+            else:
+                completion = await self.aclient.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    temperature=temperature,
+                    **kwargs,
+                )
+                choice = completion.choices[0]
+                response = cast(T, choice.message.content or "")
+
+            return LLMResponse(
+                response=response,
+                logprobs=self._extract_logprobs(choice),
+                total_tokens=(
+                    completion.usage.total_tokens if completion.usage else None
+                ),
+                provider_model=OpenAIChoice(model=model),
+            )
+        except Exception as e:
+            logger.warning(
+                f"Error responding with OpenAI (chat.completions): {e}", exc_info=True
+            )
+            if raise_:
+                raise e
+            return None
 
     def respond_sync(
         self,
@@ -47,7 +171,18 @@ class OpenAILLM(metaclass=SingletonMeta):
         raise_: bool = False,
         **kwargs: Any,
     ) -> LLMResponse[T] | None:
-        kwargs = self._process_kwargs(kwargs)
+        if self.endpoint_style == "chat_completions":
+            return self._respond_chat_sync(
+                model=model,
+                query=query,
+                response_format=response_format,
+                instructions=instructions,
+                temperature=temperature,
+                raise_=raise_,
+                kwargs=kwargs,
+            )
+
+        kwargs = self._process_kwargs(kwargs, self.client.responses.parse)
 
         try:
             if issubclass(response_format, BaseModel):
@@ -99,7 +234,18 @@ class OpenAILLM(metaclass=SingletonMeta):
         raise_: bool = False,
         **kwargs: Any,
     ) -> LLMResponse[T] | None:
-        kwargs = self._process_kwargs(kwargs)
+        if self.endpoint_style == "chat_completions":
+            return await self._respond_chat(
+                model=model,
+                query=query,
+                response_format=response_format,
+                instructions=instructions,
+                temperature=temperature,
+                raise_=raise_,
+                kwargs=kwargs,
+            )
+
+        kwargs = self._process_kwargs(kwargs, self.client.responses.parse)
 
         try:
             if issubclass(response_format, BaseModel):

--- a/think_reason_learn/core/llms/_openai/ask.py
+++ b/think_reason_learn/core/llms/_openai/ask.py
@@ -1,5 +1,6 @@
 from typing import Type, Any, cast, Dict
 import logging
+import os
 
 from openai import AsyncOpenAI, OpenAI
 from openai.types.responses import Response
@@ -7,16 +8,27 @@ from pydantic import BaseModel
 
 from .._schemas import LLMResponse, T, OpenAIChoice
 from think_reason_learn.core._singleton import SingletonMeta
-from .schemas import OpenAIChatModel, NOT_GIVEN, NotGiven
+from .schemas import OpenAIChatModel, OpenAIEndpointStyle, NOT_GIVEN, NotGiven
 
 
 logger = logging.getLogger(__name__)
 
 
 class OpenAILLM(metaclass=SingletonMeta):
-    def __init__(self, api_key: str) -> None:
-        self.client = OpenAI(api_key=api_key)
-        self.aclient = AsyncOpenAI(api_key=api_key)
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str | None = None,
+        endpoint_style: OpenAIEndpointStyle | None = None,
+        top_logprobs: int = 5,
+    ) -> None:
+        base_url = base_url or os.environ.get("OPENAI_BASE_URL") or None
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.aclient = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self.endpoint_style: OpenAIEndpointStyle = endpoint_style or (
+            "chat_completions" if base_url else "responses"
+        )
+        self.top_logprobs = top_logprobs
 
     def _process_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
@@ -129,5 +141,16 @@ class OpenAILLM(metaclass=SingletonMeta):
             return None
 
 
-def get_openai_llm(api_key: str) -> OpenAILLM | None:
-    return OpenAILLM(api_key) if api_key else None
+def get_openai_llm(
+    api_key: str,
+    base_url: str | None = None,
+    endpoint_style: OpenAIEndpointStyle | None = None,
+) -> OpenAILLM | None:
+    base_url = base_url or os.environ.get("OPENAI_BASE_URL") or None
+    if not api_key and base_url:
+        # Local OpenAI-compatible servers (Ollama, vLLM without --api-key)
+        # accept any non-empty key.
+        api_key = "ollama"
+    if not api_key:
+        return None
+    return OpenAILLM(api_key, base_url=base_url, endpoint_style=endpoint_style)

--- a/think_reason_learn/core/llms/_openai/ask.py
+++ b/think_reason_learn/core/llms/_openai/ask.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from openai import AsyncOpenAI, OpenAI
+from openai.types.chat import ChatCompletionMessageParam
 from openai.types.responses import Response
 from pydantic import BaseModel
 
@@ -42,8 +43,10 @@ class OpenAILLM(metaclass=SingletonMeta):
         query: str,
         instructions: str | NotGiven | None,
         kwargs: Dict[str, Any],
-    ) -> List[Dict[str, Any]]:
-        messages: List[Dict[str, Any]] = list(kwargs.pop("messages", None) or [])
+    ) -> List[ChatCompletionMessageParam]:
+        messages: List[ChatCompletionMessageParam] = list(
+            kwargs.pop("messages", None) or []
+        )
         if query and (not messages or messages[-1].get("role") != "user"):
             messages.append({"role": "user", "content": query})
         if instructions and not any(m.get("role") == "system" for m in messages):
@@ -71,13 +74,14 @@ class OpenAILLM(metaclass=SingletonMeta):
         messages = self._chat_messages(query, instructions, kwargs)
         kwargs.setdefault("logprobs", True)
         kwargs.setdefault("top_logprobs", self.top_logprobs)
+        if not isinstance(temperature, NotGiven):
+            kwargs.setdefault("temperature", temperature)
 
         try:
             if issubclass(response_format, BaseModel):
                 completion = self.client.chat.completions.parse(
                     model=model,
                     messages=messages,
-                    temperature=temperature,
                     response_format=response_format,
                     **kwargs,
                 )
@@ -87,7 +91,6 @@ class OpenAILLM(metaclass=SingletonMeta):
                 completion = self.client.chat.completions.create(
                     model=model,
                     messages=messages,
-                    temperature=temperature,
                     **kwargs,
                 )
                 choice = completion.choices[0]
@@ -123,13 +126,14 @@ class OpenAILLM(metaclass=SingletonMeta):
         messages = self._chat_messages(query, instructions, kwargs)
         kwargs.setdefault("logprobs", True)
         kwargs.setdefault("top_logprobs", self.top_logprobs)
+        if not isinstance(temperature, NotGiven):
+            kwargs.setdefault("temperature", temperature)
 
         try:
             if issubclass(response_format, BaseModel):
                 completion = await self.aclient.chat.completions.parse(
                     model=model,
                     messages=messages,
-                    temperature=temperature,
                     response_format=response_format,
                     **kwargs,
                 )
@@ -139,7 +143,6 @@ class OpenAILLM(metaclass=SingletonMeta):
                 completion = await self.aclient.chat.completions.create(
                     model=model,
                     messages=messages,
-                    temperature=temperature,
                     **kwargs,
                 )
                 choice = completion.choices[0]

--- a/think_reason_learn/core/llms/_openai/schemas.py
+++ b/think_reason_learn/core/llms/_openai/schemas.py
@@ -6,6 +6,14 @@ from openai._types import NOT_GIVEN as NOT_GIVEN, NotGiven as NotGiven
 
 OpenAIChatModel: TypeAlias = str | ChatModel
 
+OpenAIEndpointStyle: TypeAlias = Literal["responses", "chat_completions"]
+"""Which OpenAI API surface to call.
+
+``"responses"`` targets ``/v1/responses`` (OpenAI's hosted API).
+``"chat_completions"`` targets ``/v1/chat/completions``, the surface
+implemented by OpenAI-compatible servers such as Ollama and vLLM.
+"""
+
 
 class OpenAIChoice(BaseModel):
     """An LLM from OpenAI."""


### PR DESCRIPTION
## Summary

Users pointing TRL at a local model (Ollama, vLLM, LM Studio — anything OpenAI-compatible) previously hit a wall: the OpenAI provider only spoke `/v1/responses`, which local servers don't implement, and it hardcoded `logprobs=[]`, which breaks Reasoned Rule Mining (rule-perplexity filtering and the `average_confidence` 3-vote ensemble both depend on `response.logprobs`).

This PR makes local OpenAI-compatible servers first-class:

- `OpenAILLM` gains `base_url` and `endpoint_style="responses" | "chat_completions"` constructor params. When `endpoint_style` is unset it is auto-detected: a configured base URL (constructor arg, `OPENAI_BASE_URL` env var, or `.env`) selects `chat_completions`; otherwise the provider behaves exactly as before.
- The chat path routes plain-text calls through `chat.completions.create` and structured outputs through `chat.completions.parse` (the non-beta successor of `beta.chat.completions.parse`; the SDK floor `openai>=1.106.1` includes it), always with `logprobs=True, top_logprobs=5`, and populates `LLMResponse.logprobs` from the returned token stream.
- `OPENAI_BASE_URL` / `OPENAI_ENDPOINT_STYLE` are honored via `Settings` like the existing key settings, so the same code targets OpenAI, Ollama, vLLM, or any other OpenAI-compatible server. `OPENAI_API_KEY` falls back to a placeholder when only a base URL is set, since local servers ignore the key.
- Docs: a "Using a local model" section in the Quick Start (README + Sphinx docs).

## Design decision: extend `OpenAILLM` (Option C) rather than add a parallel class (Option B)

**Option B — new `OpenAICompatChatLLM` alongside `OpenAILLM`.** Cleanest isolation, zero risk to the existing class. But to be reachable through `LLM`'s priority dispatch it needs a new provider literal threaded through `LLMProvider`, the choice schemas and typed dicts, `models_map`, and both dispatch loops in `_ask.py` — a wide, permanent API surface for what is ultimately the same provider speaking a different dialect. Every `llm_priority` a user writes would also have to say a new provider name instead of `openai`.

**Option C (chosen) — `endpoint_style` param on `OpenAILLM`, auto-detected.** Zero breaking change: without a base URL, the `responses` path is the old behavior unchanged (regression-tested). Existing `{"provider": "openai", ...}` records keep working; local users set two env vars and change no code. One class to maintain; the chat path is two focused private methods plus shared helpers. Bonus: `OPENAI_ENDPOINT_STYLE=chat_completions` also yields token logprobs from OpenAI's hosted API, which the `responses` path never returned.

Trade-off accepted: `OpenAILLM` internally carries two code paths. Mitigated by auto-detection (users rarely think about it) and by keeping the paths as separate methods.

## Reference implementation and consumers

- **Reference:** the proven shim at `think-reason-learn-private/experiments/vcbench/tree_based/gptree_vcbench/logprobs_llm_shim.py` — this PR upstreams that shim's behavior (chat.completions + parse routing, logprobs preservation, `OPENAI_BASE_URL`/`OPENAI_API_KEY` env vars, placeholder key for local servers).
- **Immediate consumer:** the `examples/vcbench-movie-local` example folder, which currently carries its own copy of the shim. A separate follow-up commit removes that copy once this merges — deliberately not part of this PR, which is library-only.
- **Motivating datasets:** VCBench and Movie, both run against local Qwen models via Ollama, where every user so far has had to rediscover the `/v1/responses` gap and hand-port the shim.

## Deliberately out of scope

- **The shim's per-call disk cache.** It stays in the experiment harness: a request-hash cache silently collapses repeated temperature>0 samples into one response, which would corrupt RRM's 3-vote ensemble if it shipped inside the provider. If demand appears it can land later as an explicit opt-in decorator around `LLM.respond`.
- The dict-vs-object `llm_priority` trap the shim guarded against (its lines 92–93) is already handled at the library level by `LLM._val_llm_priority_and_api_keys`; a new integration test locks in that dict records reach the chat path.

## Testing

- 20 new offline tests in `tests/test_openai_chat_llm.py` (mocked SDK clients — no Ollama or API key needed): endpoint auto-detection and explicit override, both chat paths sync + async, logprobs preservation and `average_confidence`, missing-logprobs tolerance, temperature-0 preservation, error contract (`raise_`/None), `responses`-path backward-compat regression, dict-record integration through `LLM`, and `Settings` env wiring.
- Full suite: 270 passed. (`tests/test_xai_llm.py::test_instructions_injected_when_no_system_message_sync` also fails at the base commit on the dev machine — singleton pollution when real API keys are present in the environment; unrelated to this change and passes in isolation.)
- `ruff check` and `ruff format --check` clean; `pyright` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
