### PR TITLE
Optimize/policy induction

### DIFF
--- a/tests/fake_policy_llm.py
+++ b/tests/fake_policy_llm.py
@@ -1,0 +1,207 @@
+"""Deterministic fake LLM for offline PolicyInduction testing."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, List, Literal, Set, Type
+
+from think_reason_learn.core.llms import OpenAIChoice
+from think_reason_learn.core.llms._schemas import (
+    NOT_GIVEN,
+    LLMChoice,
+    LLMResponse,
+    NotGiven,
+    T,
+)
+from think_reason_learn.policy_induction._policy_induction import (
+    Answer,
+    BatchedAnswers,
+    Policies,
+    PolicyAnswer,
+)
+from think_reason_learn.policy_induction._prompts import max_policy_num_tag
+
+
+_FAKE_PROVIDER = OpenAIChoice(model="gpt-4.1-nano")
+
+# Pulls the policy text and sample out of an unbatched scoring query.
+_SINGLE_RE = re.compile(r"Policy:\n(.*?)\n\nSample:\n(.*)", re.DOTALL)
+# Pulls the policy block and sample out of a batched scoring query.
+_BATCH_RE = re.compile(r"Policies:\n(.*?)\n\nSample:\n(.*)", re.DOTALL)
+_ID_RE = re.compile(r"^id=(\d+): (.*)$", re.MULTILINE)
+
+
+class FakePolicyLLM:
+    """Drop-in replacement for ``LLM`` covering PolicyInduction's call sites.
+
+    Dispatches on ``response_format``:
+
+    1. ``str``             -- ``set_task`` template (carries the max-policy tag)
+    2. ``Policies``        -- ``_generate_policies``
+    3. ``Answer``          -- ``_score_policy_single`` (unbatched + re-query)
+    4. ``BatchedAnswers``  -- ``_score_policy_batch``
+
+    Verdicts are a pure function of (policy text, sample text), so the batched
+    and unbatched paths must agree cell-for-cell. That equality is what the
+    ``policy_batch_size=1`` test asserts.
+
+    Args:
+        n_policies: How many policies ``_generate_policies`` returns.
+        drop_ids: Local ids omitted from every batched response.
+        shift_ids: Added to every returned ``policy_id``, breaking alignment.
+        shift_first_only: Apply ``shift_ids`` to the first batch call only.
+        fail_after: Raise on batch call N and every one after it (1-indexed).
+        fail_single: Make every individual ``Answer`` call raise.
+    """
+
+    def __init__(
+        self,
+        n_policies: int = 6,
+        drop_ids: Set[int] | None = None,
+        shift_ids: int = 0,
+        shift_first_only: bool = False,
+        fail_after: int | None = None,
+        fail_single: bool = False,
+    ) -> None:
+        self.n_policies = n_policies
+        self.drop_ids = drop_ids or set()
+        self.shift_ids = shift_ids
+        self.shift_first_only = shift_first_only
+        self.fail_after = fail_after
+        self.fail_single = fail_single
+        self._call_count = 0
+        self.calls: List[Dict[str, Any]] = []
+
+    # ── Call accounting ────────────────────────────────────────────────────────
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+    def count_of(self, response_format: Any) -> int:
+        """Number of calls made with the given response_format."""
+        return sum(1 for c in self.calls if c["response_format"] is response_format)
+
+    @property
+    def batch_calls(self) -> int:
+        return self.count_of(BatchedAnswers)
+
+    @property
+    def single_calls(self) -> int:
+        return self.count_of(Answer)
+
+    def reset(self) -> None:
+        self._call_count = 0
+        self.calls = []
+
+    # ── Verdict ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def verdict(policy_text: str, sample_str: str) -> Literal["YES", "NO"]:
+        """Stable YES/NO for a (policy, sample) pair, independent of batching."""
+        digest = hashlib.md5(f"{policy_text}||{sample_str}".encode()).digest()
+        return "YES" if digest[0] % 2 == 0 else "NO"
+
+    def policy_texts(self) -> List[str]:
+        return [
+            f"Policy {i}: the founder shows trait {i}." for i in range(self.n_policies)
+        ]
+
+    # ── Dispatch ───────────────────────────────────────────────────────────────
+
+    async def respond(
+        self,
+        query: str,
+        llm_priority: List[LLMChoice],
+        response_format: Type[T],
+        instructions: str | NotGiven | None = NOT_GIVEN,
+        temperature: float | NotGiven | None = NOT_GIVEN,
+        **kwargs: Dict[str, Any],
+    ) -> LLMResponse[Any]:
+        self._call_count += 1
+        self.calls.append(
+            {
+                "query": query,
+                "response_format": response_format,
+                "instructions": instructions,
+                "n": self._call_count,
+            }
+        )
+
+        if response_format is Policies:
+            return self._policies_response()
+        if response_format is Answer:
+            return self._single_response(query)
+        if response_format is BatchedAnswers:
+            return self._batch_response(query)
+        if response_format is str:
+            return self._set_task_response()
+        raise TypeError(
+            f"FakePolicyLLM: unknown response_format {response_format!r}. "
+            "Add a handler for this new call site."
+        )
+
+    # ── Canned responses ───────────────────────────────────────────────────────
+
+    def _set_task_response(self) -> LLMResponse[str]:
+        return LLMResponse(
+            response=(
+                f"Enrich the existing policies, at most {max_policy_num_tag} "
+                "in total, using the labelled samples below."
+            ),
+            logprobs=[],
+            total_tokens=50,
+            provider_model=_FAKE_PROVIDER,
+        )
+
+    def _policies_response(self) -> LLMResponse[Policies]:
+        return LLMResponse(
+            response=Policies(policies=self.policy_texts()),
+            logprobs=[],
+            total_tokens=100,
+            provider_model=_FAKE_PROVIDER,
+        )
+
+    def _single_response(self, query: str) -> LLMResponse[Answer]:
+        if self.fail_single:
+            raise RuntimeError("FakePolicyLLM: injected single-call failure")
+        m = _SINGLE_RE.search(query)
+        if m is None:
+            raise AssertionError(f"Unparseable single-scoring query:\n{query}")
+        policy_text, sample_str = m.group(1).strip(), m.group(2).strip()
+        return LLMResponse(
+            response=Answer(answer=self.verdict(policy_text, sample_str)),
+            logprobs=[],
+            total_tokens=15,
+            provider_model=_FAKE_PROVIDER,
+        )
+
+    def _batch_response(self, query: str) -> LLMResponse[BatchedAnswers]:
+        batch_n = self.batch_calls  # 1-indexed: this call is already recorded
+        if self.fail_after is not None and batch_n >= self.fail_after:
+            raise RuntimeError("FakePolicyLLM: injected batch failure")
+
+        m = _BATCH_RE.search(query)
+        if m is None:
+            raise AssertionError(f"Unparseable batch-scoring query:\n{query}")
+        block, sample_str = m.group(1), m.group(2).strip()
+
+        shift = self.shift_ids
+        if self.shift_first_only and batch_n != 1:
+            shift = 0
+
+        answers = [
+            PolicyAnswer(
+                policy_id=int(local_id) + shift,
+                answer=self.verdict(text.strip(), sample_str),
+            )
+            for local_id, text in _ID_RE.findall(block)
+            if int(local_id) not in self.drop_ids
+        ]
+        return LLMResponse(
+            response=BatchedAnswers(answers=answers),
+            logprobs=[],
+            total_tokens=20 * max(len(answers), 1),
+            provider_model=_FAKE_PROVIDER,
+        )

--- a/tests/test_policy_induction.py
+++ b/tests/test_policy_induction.py
@@ -168,7 +168,7 @@ async def test_max_gen_batches_caps_generation(tmp_path):
 
 @pytest.mark.asyncio
 async def test_max_gen_batches_none_runs_until_class_exhaustion(tmp_path):
-    """Default behaviour is unchanged: stop only once a class runs out."""
+    """None disables the cap: generation stops only once a class runs out."""
     fake = FakePolicyLLM(n_policies=6)
     pi = make_pi(tmp_path, fake, max_gen_batches=None)
     pi._set_data(X, Y)
@@ -209,18 +209,42 @@ def test_max_gen_batches_round_trips(tmp_path):
     assert PolicyInduction.load(tmp_path / "model").max_gen_batches == 1
 
 
-def test_max_gen_batches_default_none_round_trips(tmp_path):
-    """A missing key on an old-style save restores the default, None."""
+def test_max_gen_batches_default_round_trips(tmp_path):
+    """Generation is capped at 7 batches by default, and that survives a save."""
     fake = FakePolicyLLM(n_policies=6)
-    pi = make_pi(tmp_path, fake)  # max_gen_batches left at its default, None
+    pi = make_pi(tmp_path, fake)  # max_gen_batches left at its default
+    assert pi.max_gen_batches == 7
     seed_for_scoring(pi, fake)
     pi.save(tmp_path / "model")
 
-    manifest_path = tmp_path / "model" / "policy_induction.json"
-    manifest = orjson.loads(manifest_path.read_bytes())
+    manifest = orjson.loads((tmp_path / "model" / "policy_induction.json").read_bytes())
+    assert manifest["max_gen_batches"] == 7
+    assert PolicyInduction.load(tmp_path / "model").max_gen_batches == 7
+
+
+def test_max_gen_batches_explicit_none_round_trips(tmp_path):
+    """An explicit None (uncapped) is preserved, not coerced to the default."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, max_gen_batches=None)
+    seed_for_scoring(pi, fake)
+    pi.save(tmp_path / "model")
+
+    manifest = orjson.loads((tmp_path / "model" / "policy_induction.json").read_bytes())
     assert manifest["max_gen_batches"] is None
+    assert PolicyInduction.load(tmp_path / "model").max_gen_batches is None
+
+
+def test_load_manifest_without_max_gen_batches(tmp_path):
+    """A save predating the key loads uncapped, matching how it was trained."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake)
+    seed_for_scoring(pi, fake)
+    pi.save(tmp_path / "model")
+
+    path = tmp_path / "model" / "policy_induction.json"
+    manifest = orjson.loads(path.read_bytes())
     del manifest["max_gen_batches"]
-    manifest_path.write_bytes(orjson.dumps(manifest))
+    path.write_bytes(orjson.dumps(manifest))
 
     assert PolicyInduction.load(tmp_path / "model").max_gen_batches is None
 

--- a/tests/test_policy_induction.py
+++ b/tests/test_policy_induction.py
@@ -1,67 +1,333 @@
-"""Tests for PolicyInduction."""
-# import pytest
-# import pandas as pd
-# import numpy as np
-# from think_reason_learn.policy_induction import PolicyInduction
-# from think_reason_learn.core.llms import GoogleChoice, OpenAIChoice
+"""Tests for PolicyInduction, focused on batched LLM calls."""
 
-# X = pd.DataFrame(
-#     {
-#         "founder_info": [
-#             "Alex is a serial entrepreneur with two successful exits, strong "
-#             "network in Silicon Valley, and expertise in AI.",
-#             "Jordan graduated top of class from MIT but has no prior business "
-#             "experience and limited funding.",
-#             "Taylor has 10 years in finance, secured seed funding quickly, and "
-#             "built a talented team.",
-#             "Casey started a company right out of high school, faced multiple "
-#             "failures, but persists with innovative ideas.",
-#             "Morgan is a former Google engineer with patents in machine learning "
-#             "and venture capital backing.",
-#         ]
-#     }
-# )
+from __future__ import annotations
 
-# y = np.array(["YES", "NO", "YES", "NO", "YES"]).tolist()
+import math
 
-# sav_dir = "policy_induction"
+import numpy as np
+import orjson
+import pandas as pd
+import pytest
 
-# @pytest.mark.asyncio
-# async def test_general():
-#     """Test the PolicyInduction general workflow."""
-#     pi = PolicyInduction(
-#         gen_llmc=[
-#             GoogleChoice(model="gemini-2.5-flash"),
-#             OpenAIChoice(model="gpt-4o-mini"),
-#         ],
-#         predict_llmc=[
-#             GoogleChoice(model="gemini-2.5-flash"),
-#             OpenAIChoice(model="gpt-4o-mini"),
-#         ],
-#     )
-
-#     pgit = await pi.set_task(
-#         task_description="Predict if a startup founder will be successful "
-#         "or fail based on their background.",
-#     )
-#     print(pgit)
-
-#     pi = await pi.fit(X, y, reset=True)
-
-#     df = pd.DataFrame()
-#     async for sample_index, results, final_answer, token_counter in pi.predict(X):
-#         print(f"Sample {sample_index}, Predict: {final_answer}")
-#         df[sample_index] = results
-#     print(pi.get_memory())
-#     print("predictions")
-#     print(df)
-#     pi.save(sav_dir)
-#     return pi
+from think_reason_learn.core.llms import OpenAIChoice
+from think_reason_learn.policy_induction import PolicyInduction
+from tests.fake_policy_llm import FakePolicyLLM
 
 
-# @pytest.mark.asyncio
-# async def test_load_and_predict():
-#     pi = PolicyInduction.load(sav_dir)
-#     async for idx, policy_vector, answer, token_counter in pi.predict(X):
-#         print(idx, answer)
-#     return pi
+TASK = "Predict whether a startup founder will succeed based on their background."
+
+X = pd.DataFrame(
+    {
+        "founder_info": [
+            "Alex is a serial entrepreneur with two successful exits and AI expertise.",
+            "Jordan graduated top of class from MIT but has no business experience.",
+            "Taylor has 10 years in finance and secured seed funding quickly.",
+            "Casey started a company out of high school and faced multiple failures.",
+            "Morgan is a former Google engineer with machine learning patents.",
+            "Riley has deep domain knowledge but has never managed a team.",
+            "Sam built and sold a marketplace business to a public company.",
+            "Quinn is a first-time founder working alone without funding.",
+        ]
+    }
+)
+Y = ["YES", "NO", "YES", "NO", "YES", "NO", "YES", "NO"]
+
+
+def make_pi(tmp_path, fake: FakePolicyLLM, **kw) -> PolicyInduction:
+    """A PolicyInduction wired to the fake, with a task already set."""
+    kw.setdefault("policy_batch_size", 3)
+    kw.setdefault("llm_semaphore_limit", 3)
+    pi = PolicyInduction(
+        gen_llmc=[OpenAIChoice(model="gpt-4.1-nano")],
+        confirm_requests=False,
+        save_path=tmp_path,
+        name="test_pi",
+        max_samples_as_context=4,
+        config={"cv_folds": 2, "Cs": (1.0,)},
+        _llm=fake,
+        **kw,
+    )
+    pi._task_description = TASK
+    pi._pgen_instructions_template = "Enrich policies. Max <max_policy_length>."
+    return pi
+
+
+def seed_for_scoring(pi: PolicyInduction, fake: FakePolicyLLM) -> None:
+    """Populate data + policy memory so _score_policies can run standalone."""
+    pi._set_data(X, Y)
+    pi._policy_memory = pd.DataFrame(
+        {
+            "policy": fake.policy_texts(),
+            "predictions": [None] * fake.n_policies,
+        }
+    )
+
+
+def null_cells(pi: PolicyInduction) -> int:
+    preds = pi._policy_memory["predictions"]
+    return int(sum(int(s.isna().sum()) for s in preds if s is not None))
+
+
+# ── Batching arithmetic ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_batch_call_count(tmp_path):
+    """One call per (sample, policy-chunk), and no single-policy calls."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    seed_for_scoring(pi, fake)
+
+    await pi._score_policies()
+
+    assert fake.batch_calls == len(X) * math.ceil(6 / 3) == 16
+    assert fake.single_calls == 0
+    assert null_cells(pi) == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_size_one_matches_unbatched(tmp_path):
+    """policy_batch_size=1 uses the single-item path and yields the same matrix."""
+    fake_b = FakePolicyLLM(n_policies=6)
+    pi_b = make_pi(tmp_path / "batched", fake_b, policy_batch_size=3)
+    seed_for_scoring(pi_b, fake_b)
+    await pi_b._score_policies()
+
+    fake_s = FakePolicyLLM(n_policies=6)
+    pi_s = make_pi(tmp_path / "single", fake_s, policy_batch_size=1)
+    seed_for_scoring(pi_s, fake_s)
+    await pi_s._score_policies()
+
+    assert fake_s.batch_calls == 0
+    assert fake_s.single_calls == len(X) * 6 == 48
+
+    np.testing.assert_array_equal(
+        pi_b._build_feature_matrix()[0], pi_s._build_feature_matrix()[0]
+    )
+
+
+@pytest.mark.parametrize("bs", [1, 2, 10])
+def test_estimate_fit_requests_batched(tmp_path, bs):
+    """Scoring estimate is ceil(missing policies / batch) summed over samples."""
+    fake = FakePolicyLLM(n_policies=5)
+    pi = make_pi(tmp_path, fake, policy_batch_size=bs)
+    seed_for_scoring(pi, fake)
+
+    # Policy 0 fully scored, policy 1 half scored, policies 2-4 absent entirely.
+    sample_keys = [str(i) for i in X.index]
+    scores = {
+        "0": {k: "YES" for k in sample_keys},
+        "1": {k: (None if i % 2 else "NO") for i, k in enumerate(sample_keys)},
+    }
+    pi._write_ckpt(
+        pi._FIT_CKPT_NAME, {"policies": fake.policy_texts(), "scores": scores}
+    )
+
+    # Per sample: 3 absent policies, plus policy 1 on odd-indexed samples.
+    expected = sum(
+        math.ceil((3 + (1 if i % 2 else 0)) / bs) for i in range(len(sample_keys))
+    )
+    key = next(k for k in pi._estimate_fit_requests() if "scoring" in k)
+    assert pi._estimate_fit_requests()[key] == expected
+
+
+@pytest.mark.parametrize("bs", [1, 3, 10])
+def test_estimate_predict_requests_batched(tmp_path, bs):
+    """Predict estimate batches over the nonzero-weight policies only."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=bs)
+    pi._feature_order_ = np.array([str(i) for i in range(6)], dtype=str)
+
+    class _LR:
+        coef_ = np.array([[1.0, 0.0, 2.0, 0.0, 3.0, 0.0]])
+
+    pi._lr = _LR()  # type: ignore[assignment]
+
+    key = next(k for k in pi._estimate_predict_requests(X) if "predict" in k)
+    assert pi._estimate_predict_requests(X)[key] == len(X) * math.ceil(3 / bs)
+
+
+# ── Alignment and recovery ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_id_misalignment_requeries_individually(tmp_path):
+    """Shifted ids resolve to nothing, so the whole chunk is re-queried."""
+    fake = FakePolicyLLM(n_policies=6, shift_ids=100, shift_first_only=True)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    seed_for_scoring(pi, fake)
+
+    await pi._score_policies()
+
+    assert fake.single_calls == 3  # exactly the first chunk
+    assert null_cells(pi) == 0
+
+
+@pytest.mark.asyncio
+async def test_partial_batch_requeries_only_missing(tmp_path):
+    """A dropped id costs exactly one extra single call per batch."""
+    fake = FakePolicyLLM(n_policies=6, drop_ids={2})
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    seed_for_scoring(pi, fake)
+
+    await pi._score_policies()
+
+    assert fake.batch_calls == 16
+    assert fake.single_calls == 16
+    assert null_cells(pi) == 0
+
+
+@pytest.mark.asyncio
+async def test_persistent_miss_leaves_cells_none(tmp_path):
+    """When the re-query also fails, cells stay unscored rather than wrong."""
+    fake = FakePolicyLLM(n_policies=6, drop_ids={2}, fail_single=True)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    seed_for_scoring(pi, fake)
+
+    await pi._score_policies()  # must not raise
+
+    # Local id 2 of each chunk = policies 2 and 5.
+    preds = pi._policy_memory["predictions"]
+    assert preds.at[2].isna().all() and preds.at[5].isna().all()
+    for pid in (0, 1, 3, 4):
+        assert not preds.at[pid].isna().any()
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_does_not_fan_out(tmp_path):
+    """A failed batch call leaves cells unscored without N individual retries."""
+    fake = FakePolicyLLM(n_policies=6, fail_after=1)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    seed_for_scoring(pi, fake)
+
+    await pi._score_policies()
+
+    assert fake.single_calls == 0
+    assert null_cells(pi) == len(X) * 6
+
+
+# ── Checkpointing ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_resume_across_batch_boundary(tmp_path):
+    """A resumed run re-chunks only the cells that are still missing."""
+    fake = FakePolicyLLM(n_policies=6, fail_after=9)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3, llm_semaphore_limit=1)
+    seed_for_scoring(pi, fake)
+
+    await pi._score_policies()
+
+    # 16 units in order, 2 per sample; calls 9+ fail => samples 4-7 unscored.
+    ckpt = pi._read_ckpt(pi._FIT_CKPT_NAME)
+    assert ckpt is not None
+    scores = ckpt["scores"]
+    for pid in range(6):
+        row = scores[str(pid)]
+        assert all(row[str(s)] is not None for s in range(4))
+        assert all(row[str(s)] is None for s in range(4, 8))
+
+    # Resume on a fresh instance pointed at the same save_path.
+    fake2 = FakePolicyLLM(n_policies=6)
+    pi2 = make_pi(tmp_path, fake2, policy_batch_size=3, llm_semaphore_limit=1)
+    seed_for_scoring(pi2, fake2)
+
+    await pi2._score_policies()
+
+    assert fake2.batch_calls == 4 * math.ceil(6 / 3) == 8
+    assert null_cells(pi2) == 0
+
+
+# ── Persistence ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_policy_batch_size_round_trips(tmp_path):
+    """The saved batch size is restored, keeping scoring and predict in sync."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=4)
+    seed_for_scoring(pi, fake)
+    await pi._score_policies()
+    pi.save(tmp_path / "model")
+
+    manifest = orjson.loads((tmp_path / "model" / "policy_induction.json").read_bytes())
+    assert manifest["version"] == 3
+    assert manifest["policy_batch_size"] == 4
+    assert PolicyInduction.load(tmp_path / "model").policy_batch_size == 4
+
+
+def test_load_tolerates_null_policy_batch_size(tmp_path):
+    """A present-but-None key must fall back to the default, never become None."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=4)
+    seed_for_scoring(pi, fake)
+    pi.save(tmp_path / "model")
+
+    path = tmp_path / "model" / "policy_induction.json"
+    manifest = orjson.loads(path.read_bytes())
+    manifest["policy_batch_size"] = None
+    path.write_bytes(orjson.dumps(manifest))
+
+    assert PolicyInduction.load(tmp_path / "model").policy_batch_size == 10
+
+
+@pytest.mark.parametrize("bad", [0, -1, 51, 3.0, "3", None, True])
+def test_validate_init_rejects_bad_batch_size(bad):
+    with pytest.raises(ValueError, match="policy_batch_size"):
+        PolicyInduction(
+            gen_llmc=[OpenAIChoice(model="gpt-4.1-nano")],
+            policy_batch_size=bad,
+        )
+
+
+# ── Predict ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fit_and_predict_batched(tmp_path):
+    """End-to-end fit, then predict batching over nonzero-weight policies."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+
+    await pi.fit(X, Y)
+    assert not (tmp_path / pi._FIT_CKPT_NAME).exists()
+
+    n_used = int(np.count_nonzero(pi.lr.coef_[0]))
+    fake.reset()
+    records = [rec async for rec in pi.predict(X)]
+
+    assert len(records) == len(X)
+    assert fake.batch_calls == len(X) * math.ceil(n_used / 3)
+
+
+@pytest.mark.asyncio
+async def test_predict_skips_sample_on_total_miss(tmp_path):
+    """No answers at all means no record and a retained checkpoint."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    await pi.fit(X, Y)
+
+    fake.fail_after = 1
+    fake.fail_single = True
+    records = [rec async for rec in pi.predict(X)]
+
+    assert records == []
+    assert (tmp_path / pi._PREDICT_CKPT_NAME).exists()
+
+
+@pytest.mark.asyncio
+async def test_predict_warns_on_partial_miss(tmp_path, caplog):
+    """A partial miss still yields, but says so instead of silently scoring 0."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, policy_batch_size=3)
+    await pi.fit(X, Y)
+    if int(np.count_nonzero(pi.lr.coef_[0])) < 2:
+        pytest.skip("model kept too few policies to exercise a partial miss")
+
+    fake.drop_ids = {0}
+    fake.fail_single = True
+    with caplog.at_level("WARNING"):
+        records = [rec async for rec in pi.predict(X)]
+
+    assert len(records) == len(X)
+    assert any("answers missing after re-query" in m for m in caplog.messages)

--- a/tests/test_policy_induction.py
+++ b/tests/test_policy_induction.py
@@ -11,6 +11,7 @@ import pytest
 
 from think_reason_learn.core.llms import OpenAIChoice
 from think_reason_learn.policy_induction import PolicyInduction
+from think_reason_learn.policy_induction._policy_induction import Policies
 from tests.fake_policy_llm import FakePolicyLLM
 
 
@@ -145,6 +146,83 @@ def test_estimate_predict_requests_batched(tmp_path, bs):
 
     key = next(k for k in pi._estimate_predict_requests(X) if "predict" in k)
     assert pi._estimate_predict_requests(X)[key] == len(X) * math.ceil(3 / bs)
+
+
+# ── Generation batch cap ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_gen_batches_caps_generation(tmp_path):
+    """max_gen_batches stops generation early even though both classes remain."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, max_gen_batches=1)
+    pi._set_data(X, Y)
+
+    policies = await pi._run_generation(pi._get_gen_instructions())
+
+    assert fake.count_of(Policies) == 1
+    assert policies == fake.policy_texts()
+    ckpt = pi._read_ckpt(pi._FIT_CKPT_NAME)
+    assert ckpt is not None and ckpt["batches_done"] == 1
+
+
+@pytest.mark.asyncio
+async def test_max_gen_batches_none_runs_until_class_exhaustion(tmp_path):
+    """Default behaviour is unchanged: stop only once a class runs out."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, max_gen_batches=None)
+    pi._set_data(X, Y)
+
+    await pi._run_generation(pi._get_gen_instructions())
+
+    # 8 rows, 4 YES / 4 NO, batches of 4 (2 YES + 2 NO) => exhausts after 2.
+    assert fake.count_of(Policies) == 2
+
+
+@pytest.mark.parametrize("cap", [1, 2, 5])
+def test_estimate_fit_requests_respects_max_gen_batches(tmp_path, cap):
+    """The generation estimate is capped the same way _run_generation is."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, max_gen_batches=cap)
+    pi._set_data(X, Y)
+
+    key = next(k for k in pi._estimate_fit_requests() if "generation" in k)
+    assert pi._estimate_fit_requests()[key] == min(cap, 2)
+
+
+@pytest.mark.parametrize("bad", [0, -1, 1.5, "1", True])
+def test_validate_init_rejects_bad_max_gen_batches(bad):
+    with pytest.raises(ValueError, match="max_gen_batches"):
+        PolicyInduction(
+            gen_llmc=[OpenAIChoice(model="gpt-4.1-nano")],
+            max_gen_batches=bad,
+        )
+
+
+def test_max_gen_batches_round_trips(tmp_path):
+    """The saved cap is restored on load."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake, max_gen_batches=1)
+    seed_for_scoring(pi, fake)
+    pi.save(tmp_path / "model")
+
+    assert PolicyInduction.load(tmp_path / "model").max_gen_batches == 1
+
+
+def test_max_gen_batches_default_none_round_trips(tmp_path):
+    """A missing key on an old-style save restores the default, None."""
+    fake = FakePolicyLLM(n_policies=6)
+    pi = make_pi(tmp_path, fake)  # max_gen_batches left at its default, None
+    seed_for_scoring(pi, fake)
+    pi.save(tmp_path / "model")
+
+    manifest_path = tmp_path / "model" / "policy_induction.json"
+    manifest = orjson.loads(manifest_path.read_bytes())
+    assert manifest["max_gen_batches"] is None
+    del manifest["max_gen_batches"]
+    manifest_path.write_bytes(orjson.dumps(manifest))
+
+    assert PolicyInduction.load(tmp_path / "model").max_gen_batches is None
 
 
 # ── Alignment and recovery ─────────────────────────────────────────────────────

--- a/think_reason_learn/policy_induction/_policy_induction.py
+++ b/think_reason_learn/policy_induction/_policy_induction.py
@@ -137,9 +137,9 @@ class PolicyInduction:
             fill its share, so imbalanced datasets won't have every
             majority-class row shown during generation.
         max_samples_as_context: Samples per generation batch (max 100).
-        max_gen_batches: Cap on the number of generation batches. Generation
-            stops at this many batches even if both classes still have rows
-            left. None (default) keeps the original behaviour: stop only once
+        max_gen_batches: Cap on the number of generation batches (default 7).
+            Generation stops at this many batches even if both classes still
+            have rows left. Set to None to disable the cap and stop only once
             either class runs out.
         policy_batch_size: Number of policies judged per LLM call (1-50). One
             call carries one sample and up to this many policies, returning
@@ -1619,8 +1619,10 @@ class PolicyInduction:
             max_policy_length=m["max_policy_length"],
             class_ratio=tuple(m["class_ratio"]),
             max_samples_as_context=m["max_samples_as_context"],
-            # Default is None either way, so a missing key (old saves) and an
-            # explicit null both resolve correctly with a plain .get().
+            # Plain .get(), deliberately not falling back to the constructor
+            # default: None is a meaningful value here (uncapped), so it has
+            # to survive a round trip. Old saves lacking the key also load
+            # uncapped, which is how they were actually trained.
             max_gen_batches=m.get("max_gen_batches"),
             # `or`, not get(key, 10): save() writes this key unconditionally,
             # so a present-but-None value would defeat a two-arg get default.

--- a/think_reason_learn/policy_induction/_policy_induction.py
+++ b/think_reason_learn/policy_induction/_policy_induction.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
+import math
 import os
 import re
 import time
@@ -20,7 +21,6 @@ from pathlib import Path
 from typing import (
     Any,
     AsyncGenerator,
-    Callable,
     Dict,
     Generator,
     Iterable,
@@ -50,6 +50,7 @@ from think_reason_learn.core.exceptions import DataError, LLMError
 from think_reason_learn.core.llms import LLMChoice, TokenCounter, llm
 from ._prompts import (
     POLICY_GEN_INSTRUCTIONS,
+    POLICY_PREDICT_BATCH_INSTRUCTIONS,
     POLICY_PREDICT_INSTRUCTIONS,
     max_policy_num_tag,
 )
@@ -70,6 +71,21 @@ class Policies(BaseModel):
 
 class Answer(BaseModel):
     answer: Literal["YES", "NO"]
+
+
+class PolicyAnswer(BaseModel):
+    policy_id: int = Field(
+        ...,
+        description="Id of the policy this answer applies to, copied exactly "
+        "from the policy list in the prompt.",
+    )
+    answer: Literal["YES", "NO"]
+
+
+class BatchedAnswers(BaseModel):
+    answers: List[PolicyAnswer] = Field(
+        ..., description="Exactly one answer per policy id given in the prompt."
+    )
 
 
 # ── Config ─────────────────────────────────────────────────────────────────────
@@ -121,12 +137,20 @@ class PolicyInduction:
             fill its share, so imbalanced datasets won't have every
             majority-class row shown during generation.
         max_samples_as_context: Samples per generation batch (max 100).
-        p_predict_update_interval: Log progress every N policies during scoring.
+        policy_batch_size: Number of policies judged per LLM call (1-50). One
+            call carries one sample and up to this many policies, returning
+            one answer per policy. 1 restores the original one-call-per-
+            (policy, sample) behaviour. Answers missing from a batch response
+            are re-queried individually. The same value governs both fit-time
+            scoring and predict(), so features are always drawn the same way.
+        p_predict_update_interval: Log progress every N LLM calls during scoring.
         save_path: Directory for checkpoints and saved models.
         name: Instance name (alphanumeric + underscores only).
         random_state: Base random seed.
         confirm_requests: Before fit()/predict() make any LLM calls, print an
             estimated request count per model and require a y/n confirmation.
+        _llm: LLM instance for testing (dependency injection). If None, uses
+            the global llm.
     """
 
     def __init__(
@@ -140,16 +164,19 @@ class PolicyInduction:
         max_policy_length: int = 20,
         class_ratio: Tuple[float, float] = (1.0, 1.0),
         max_samples_as_context: int = 10,
+        policy_batch_size: int = 10,
         p_predict_update_interval: int = 10,
         save_path: str | PathLike[str] | None = None,
         name: str | None = None,
         random_state: int = 0,
         confirm_requests: bool = True,
+        _llm: Any = None,
     ):
         self._validate_init(
             max_policy_length=max_policy_length,
             class_ratio=class_ratio,
             llm_semaphore_limit=llm_semaphore_limit,
+            policy_batch_size=policy_batch_size,
             p_predict_update_interval=p_predict_update_interval,
             save_path=save_path,
             name=name,
@@ -166,11 +193,13 @@ class PolicyInduction:
         self.max_policy_length = max_policy_length
         self.random_state = random_state
         self.max_samples_as_context = max_samples_as_context
+        self.policy_batch_size = policy_batch_size
         self.p_predict_update_interval = p_predict_update_interval
         self.confirm_requests = confirm_requests
         self.name: str = self._parse_name(name)
         self.save_path: Path = self._parse_save_path(save_path)
 
+        self._llm_instance: Any = _llm if _llm is not None else llm
         self._token_counter: TokenCounter = TokenCounter()
         self._llm_semaphore = asyncio.Semaphore(llm_semaphore_limit)
         self._pgen_instructions_template: str | None = None
@@ -241,6 +270,11 @@ class PolicyInduction:
             raise ValueError("class_ratio must be two positive floats")
         if kw["llm_semaphore_limit"] <= 0:
             raise ValueError("llm_semaphore_limit must be > 0")
+        # Upper bound guards against output-token truncation: the LLM layer has
+        # no retry, and a truncated structured response is a hard parse failure.
+        pbs = kw["policy_batch_size"]
+        if not (isinstance(pbs, int) and not isinstance(pbs, bool) and 0 < pbs <= 50):
+            raise ValueError("policy_batch_size must be an int in [1, 50]")
         if kw["p_predict_update_interval"] <= 0:
             raise ValueError("p_predict_update_interval must be > 0")
         if not (kw["save_path"] is None or isinstance(kw["save_path"], (str, Path))):
@@ -381,7 +415,7 @@ class PolicyInduction:
             return instructions_template
 
         async with self._llm_semaphore:
-            response = await llm.respond(
+            response = await self._llm_instance.respond(
                 query=f"Generate policies for:\n{task_description}",
                 llm_priority=self.gen_llmc,
                 response_format=str,
@@ -432,7 +466,12 @@ class PolicyInduction:
             raise RuntimeError("Aborted by user before making API requests.")
 
     def _estimate_fit_requests(self) -> Dict[str, int]:
-        """Estimate remaining LLM calls for fit(), accounting for any checkpoint."""
+        """Estimate remaining LLM calls for fit(), accounting for any checkpoint.
+
+        Approximate: answers missing from a batched response are re-queried
+        individually, which can add up to policy_batch_size - 1 extra calls
+        per batch.
+        """
         ckpt = self._read_ckpt(self._FIT_CKPT_NAME) or {}
         batches_done: int = ckpt.get("batches_done", 0)
         total_batches = sum(
@@ -443,16 +482,22 @@ class PolicyInduction:
         policies = ckpt.get("policies")
         n_policies = len(policies) if policies else self.max_policy_length
         scores: dict = ckpt.get("scores", {})
-        n_samples = len(self._X) if self._X is not None else 0
 
-        score_remaining = 0
+        # Scoring is sample-major (one call per sample per policy chunk) while
+        # the checkpoint is policy-major, so pivot to per-sample counts first.
+        # A cell counts as remaining when it is absent OR explicitly None.
+        sample_keys = [str(i) for i in self._X.index] if self._X is not None else []
+        missing_per_sample: Dict[str, int] = {k: 0 for k in sample_keys}
         for i in range(n_policies):
-            existing = scores.get(str(i))
-            if not existing:
-                score_remaining += n_samples
-            else:
-                score_remaining += sum(1 for v in existing.values() if v is None)
-                score_remaining += max(n_samples - len(existing), 0)
+            existing = scores.get(str(i)) or {}
+            for k in sample_keys:
+                if existing.get(k) is None:
+                    missing_per_sample[k] += 1
+        score_remaining = sum(
+            math.ceil(c / self.policy_batch_size)
+            for c in missing_per_sample.values()
+            if c
+        )
 
         return {
             f"{self._llmc_label(self.gen_llmc[0])} (generation)": gen_remaining,
@@ -460,7 +505,12 @@ class PolicyInduction:
         }
 
     def _estimate_predict_requests(self, samples: pd.DataFrame) -> Dict[str, int]:
-        """Estimate remaining LLM calls for predict(), accounting for any checkpoint."""
+        """Estimate remaining LLM calls for predict(), accounting for any checkpoint.
+
+        Approximate: answers missing from a batched response are re-queried
+        individually, which can add up to policy_batch_size - 1 extra calls
+        per batch.
+        """
         ckpt = self._read_ckpt(self._PREDICT_CKPT_NAME) or {}
         done_ids = set(ckpt.get("completed", {}).keys())
         remaining_samples = sum(1 for idx in samples.index if str(idx) not in done_ids)
@@ -473,7 +523,10 @@ class PolicyInduction:
         else:
             n_policies = self.max_policy_length
         label = self._llmc_label(self.predict_llmc[0])
-        return {f"{label} (predict)": remaining_samples * n_policies}
+        return {
+            f"{label} (predict)": remaining_samples
+            * math.ceil(n_policies / self.policy_batch_size)
+        }
 
     # ── Checkpointing ───────────────────────────────────────────────────────────
 
@@ -516,9 +569,9 @@ class PolicyInduction:
     # cleared checkpoints that could describe different generated policies.
     _FIT_CKPT_NAME = "fit_checkpoint.json"
 
-    # Flush a checkpoint after this many samples complete within a single
-    # policy's scoring pass, so interrupting mid-policy on a large dataset
-    # still saves whatever finished instead of losing the whole policy.
+    # Flush a checkpoint after this many (policy, sample) cells complete,
+    # anywhere in the scoring pass, so interrupting a large run still saves
+    # whatever finished instead of losing it.
     _SCORING_CKPT_EVERY = 25
 
     # Single checkpoint file for predict(), same automatic/unconditional
@@ -565,7 +618,7 @@ class PolicyInduction:
                 f"SAMPLES:\n{samples_str}\n\n"
             )
             async with self._llm_semaphore:
-                response = await llm.respond(
+                response = await self._llm_instance.respond(
                     query=query,
                     llm_priority=self.gen_llmc,
                     response_format=Policies,
@@ -670,105 +723,160 @@ class PolicyInduction:
         ckpt["scores"] = scores
         self._write_ckpt(self._FIT_CKPT_NAME, ckpt)
 
-    async def _score_single_policy(
+    async def _score_policy_single(
         self,
-        policy: str,
-        samples: pd.DataFrame,
-        existing: pd.Series | None = None,
-        on_progress: Callable[[pd.Series], None] | None = None,
-    ) -> pd.Series:
-        """Score one policy, resuming from `existing` and checkpointing as it goes.
+        sample_str: str,
+        policy_text: str,
+        token_counter: TokenCounter,
+        caller: str,
+    ) -> Literal["YES", "NO"] | None:
+        """Ask one policy about one sample. Returns None if it can't be answered.
 
-        Only samples still null in `existing` are (re)scored. `on_progress`
-        is called with the current partial Series every
-        `_SCORING_CKPT_EVERY` completions, and once more on cancellation, so
-        interrupting mid-policy on a large dataset still keeps whatever
-        finished instead of losing the whole policy.
+        This is the original, unbatched call. It is used directly when
+        policy_batch_size == 1, and as the re-query path for answers missing
+        from a batched response.
         """
-        out = (
-            existing.copy()
-            if existing is not None
-            else pd.Series([None] * len(samples), index=samples.index, dtype="object")
-        )
-        pending = samples.loc[out.isna()]
-        done_q: asyncio.Queue[None] = asyncio.Queue()
-
-        async def worker(row_idx: Any, row: pd.Series) -> None:
-            try:
-                sample_str = "\n".join(f"{col}: {row[col]}" for col in row.index)
-                query = (
-                    f"Task description:\n{self._task_description}\n\n"
-                    f"Policy:\n{policy}\n\n"
-                    f"Sample:\n{sample_str}\n\n"
-                )
-                async with self._llm_semaphore:
-                    response = await llm.respond(
-                        query=query,
-                        llm_priority=self.predict_llmc,
-                        instructions=POLICY_PREDICT_INSTRUCTIONS,
-                        response_format=Answer,
-                        temperature=self.predict_temperature,
-                    )
-                await self._token_counter.append(
-                    provider=response.provider_model.provider,
-                    model=response.provider_model.model,
-                    value=response.total_tokens,
-                    caller="PolicyInduction.score_policy",
-                )
-                if response.response is None:
-                    raise LLMError("No response from LLM")
-                txt = str(response.response.answer).strip().upper().strip('".,;:')
-                out.at[row_idx] = (
-                    txt
-                    if txt in {"YES", "NO"}
-                    else "YES"
-                    if "YES" in txt
-                    else "NO"
-                    if "NO" in txt
-                    else None
-                )
-            except Exception:
-                logger.warning("Scoring worker error", exc_info=True)
-                out.at[row_idx] = None
-            finally:
-                done_q.put_nowait(None)
-
-        it = iter(pending.iterrows())
-        in_flight = 0
-        since_checkpoint = 0
         try:
-            async with asyncio.TaskGroup() as tg:
-                for _ in range(self.llm_semaphore_limit):
-                    try:
-                        idx, row = next(it)
-                        tg.create_task(worker(idx, row))
-                        in_flight += 1
-                    except StopIteration:
-                        break
-                while in_flight > 0:
-                    await done_q.get()
-                    in_flight -= 1
-                    since_checkpoint += 1
-                    if (
-                        on_progress is not None
-                        and since_checkpoint >= self._SCORING_CKPT_EVERY
-                    ):
-                        on_progress(out.copy())
-                        since_checkpoint = 0
-                    try:
-                        idx, row = next(it)
-                        tg.create_task(worker(idx, row))
-                        in_flight += 1
-                    except StopIteration:
-                        pass
-        finally:
-            if on_progress is not None and since_checkpoint > 0:
-                on_progress(out.copy())
+            query = (
+                f"Task description:\n{self._task_description}\n\n"
+                f"Policy:\n{policy_text}\n\n"
+                f"Sample:\n{sample_str}\n\n"
+            )
+            async with self._llm_semaphore:
+                response = await self._llm_instance.respond(
+                    query=query,
+                    llm_priority=self.predict_llmc,
+                    instructions=POLICY_PREDICT_INSTRUCTIONS,
+                    response_format=Answer,
+                    temperature=self.predict_temperature,
+                )
+            await token_counter.append(
+                provider=response.provider_model.provider,
+                model=response.provider_model.model,
+                value=response.total_tokens,
+                caller=caller,
+            )
+            if response.response is None:
+                raise LLMError("No response from LLM")
+            txt = str(response.response.answer).strip().upper().strip('".,;:')
+            return (
+                cast(Literal["YES", "NO"], txt)
+                if txt in {"YES", "NO"}
+                else "YES"
+                if "YES" in txt
+                else "NO"
+                if "NO" in txt
+                else None
+            )
+        except Exception:
+            logger.warning("Scoring worker error", exc_info=True)
+            return None
 
+    async def _score_policy_batch(
+        self,
+        sample_str: str,
+        policies: Sequence[Tuple[str, str]],
+        token_counter: TokenCounter,
+        caller: str,
+    ) -> Dict[str, Literal["YES", "NO"]]:
+        """Judge one sample against several policies in a single LLM call.
+
+        Shared by fit-time scoring and predict(), so both paths always draw
+        features the same way.
+
+        Args:
+            sample_str: The rendered sample.
+            policies: (key, policy_text) pairs. Keys are opaque here and are
+                what the returned mapping is keyed by; the prompt uses its own
+                0..n-1 ids, so the model never sees them.
+            token_counter: Counter to charge this call to.
+            caller: Label recorded on the token counter.
+
+        Returns:
+            key -> "YES"/"NO" for every policy successfully judged. Keys absent
+            from the mapping could not be resolved even after an individual
+            re-query; the caller decides what that means.
+        """
+        if not policies:
+            return {}
+        if len(policies) == 1:
+            key, text = policies[0]
+            ans = await self._score_policy_single(
+                sample_str, text, token_counter, caller
+            )
+            return {key: ans} if ans is not None else {}
+
+        local_ids = {i: key for i, (key, _) in enumerate(policies)}
+        policies_block = "\n".join(
+            f"id={i}: {text}" for i, (_, text) in enumerate(policies)
+        )
+        query = (
+            f"Task description:\n{self._task_description}\n\n"
+            f"Policies:\n{policies_block}\n\n"
+            f"Sample:\n{sample_str}\n\n"
+        )
+
+        out: Dict[str, Literal["YES", "NO"]] = {}
+        try:
+            async with self._llm_semaphore:
+                response = await self._llm_instance.respond(
+                    query=query,
+                    llm_priority=self.predict_llmc,
+                    instructions=POLICY_PREDICT_BATCH_INSTRUCTIONS,
+                    response_format=BatchedAnswers,
+                    temperature=self.predict_temperature,
+                )
+            await token_counter.append(
+                provider=response.provider_model.provider,
+                model=response.provider_model.model,
+                value=response.total_tokens,
+                caller=caller,
+            )
+            if response.response is None:
+                raise LLMError("No response from LLM")
+            # Pydantic already constrains `answer` to the literal, so only the
+            # id needs checking. Unknown/duplicate ids are dropped and fall
+            # through to the individual re-query below.
+            for item in response.response.answers:
+                key = local_ids.get(item.policy_id)
+                if key is not None and key not in out:
+                    out[key] = item.answer
+        except Exception:
+            # Deliberately no re-query here: if the call itself failed, the
+            # provider is unhealthy and fanning out to N individual calls
+            # would be worse than not batching at all. Unanswered cells stay
+            # missing and are retried on the next resume, as before.
+            logger.warning("Batched scoring worker error", exc_info=True)
+            return out
+
+        missing = [(key, text) for key, text in policies if key not in out]
+        if missing:
+            logger.warning(
+                "Batched scoring returned %d/%d answers; re-querying %d individually.",
+                len(out),
+                len(policies),
+                len(missing),
+            )
+            results = await asyncio.gather(
+                *(
+                    self._score_policy_single(sample_str, text, token_counter, caller)
+                    for _, text in missing
+                )
+            )
+            for (key, _), ans in zip(missing, results):
+                if ans is not None:
+                    out[key] = ans
         return out
 
+    def _render_sample(self, row: pd.Series) -> str:
+        return "\n".join(f"{col}: {row[col]}" for col in row.index)
+
     async def _score_policies(self) -> None:
-        """Score all unscored/partially-scored policies; checkpoint as it goes."""
+        """Score every unscored (policy, sample) cell; checkpoint as it goes.
+
+        Iterates sample-major so each LLM call carries one sample and up to
+        `policy_batch_size` policies.
+        """
         if self._X is None or self._y is None:
             raise ValueError("X and y must be set before scoring.")
 
@@ -776,44 +884,108 @@ class PolicyInduction:
         self._load_scoring_ckpt()
         self._fix_memory()
 
-        def needs_work(val: Any) -> bool:
-            return not isinstance(val, pd.Series) or bool(val.isnull().any())
+        # Materialise a full-length Series for every policy up front so workers
+        # only ever write into an existing cell. Side effect: the checkpoint now
+        # also holds all-None rows for untouched policies, where they used to be
+        # omitted — both _load_scoring_ckpt and _estimate_fit_requests treat a
+        # None cell as unscored, so this is equivalent.
+        for pid in self._policy_memory.index:
+            val = self._policy_memory.at[pid, "predictions"]
+            self._policy_memory.at[pid, "predictions"] = (  # type: ignore
+                val.reindex(self._X.index)
+                if isinstance(val, pd.Series)
+                else pd.Series(
+                    [None] * len(self._X), index=self._X.index, dtype="object"
+                )
+            )
+        series_by_pid = {
+            pid: self._policy_memory.at[pid, "predictions"]
+            for pid in self._policy_memory.index
+        }
 
-        unscored = [
-            idx
-            for idx in self._policy_memory.index
-            if needs_work(self._policy_memory.at[idx, "predictions"])
+        # Cells still needing work, grouped by sample.
+        pending: Dict[Any, List[Any]] = {}
+        for pid, s in series_by_pid.items():
+            for sidx in s.index[s.isna()]:
+                pending.setdefault(sidx, []).append(pid)
+
+        # Flatten to units of (sample, policy chunk).
+        bs = self.policy_batch_size
+        units: List[Tuple[Any, List[Any]]] = [
+            (sidx, pids[i : i + bs])
+            for sidx, pids in pending.items()
+            for i in range(0, len(pids), bs)
         ]
-        total = len(unscored)
-        already_done = len(self._policy_memory) - total
-        logger.info(f"Scoring {total} policies.")
 
-        for i, policy_idx in enumerate(
-            tqdm(
-                unscored,
-                initial=already_done,
-                total=len(self._policy_memory),
-                desc="[SCORE]",
-                unit="",
-                bar_format=_BAR_FORMAT,
-                ascii=_BAR_ASCII,
-            )
-        ):
-            policy = str(self._policy_memory.at[policy_idx, "policy"])
-            existing = self._policy_memory.at[policy_idx, "predictions"]
-            existing = existing if isinstance(existing, pd.Series) else None
+        total_cells = len(self._policy_memory) * len(self._X)
+        pending_cells = sum(len(p) for p in pending.values())
+        logger.info(
+            f"Scoring {pending_cells} (policy, sample) cells in {len(units)} LLM calls."
+        )
 
-            def on_progress(partial: pd.Series, _idx: Any = policy_idx) -> None:
-                self._policy_memory.at[_idx, "predictions"] = partial  # type: ignore
+        done_q: asyncio.Queue[int] = asyncio.Queue()
+
+        async def worker(sidx: Any, pids: List[Any]) -> None:
+            try:
+                sample_str = self._render_sample(self._X.loc[sidx])  # type: ignore
+                answers = await self._score_policy_batch(
+                    sample_str=sample_str,
+                    policies=[
+                        (str(pid), str(self._policy_memory.at[pid, "policy"]))
+                        for pid in pids
+                    ],
+                    token_counter=self._token_counter,
+                    caller="PolicyInduction.score_policy",
+                )
+                for pid in pids:
+                    series_by_pid[pid].at[sidx] = answers.get(str(pid))
+            except Exception:
+                logger.warning("Scoring worker error", exc_info=True)
+            finally:
+                done_q.put_nowait(len(pids))
+
+        it = iter(units)
+        in_flight = 0
+        since_checkpoint = 0
+        calls_done = 0
+        pbar = tqdm(
+            total=total_cells,
+            initial=total_cells - pending_cells,
+            desc="[SCORE]",
+            unit="",
+            bar_format=_BAR_FORMAT,
+            ascii=_BAR_ASCII,
+        )
+        try:
+            async with asyncio.TaskGroup() as tg:
+                for _ in range(self.llm_semaphore_limit):
+                    try:
+                        sidx, pids = next(it)
+                    except StopIteration:
+                        break
+                    tg.create_task(worker(sidx, pids))
+                    in_flight += 1
+                while in_flight > 0:
+                    n = await done_q.get()
+                    in_flight -= 1
+                    calls_done += 1
+                    since_checkpoint += n
+                    pbar.update(n)
+                    if since_checkpoint >= self._SCORING_CKPT_EVERY:
+                        self._save_scoring_ckpt()
+                        since_checkpoint = 0
+                    if calls_done % self.p_predict_update_interval == 0:
+                        logger.info(f"Scored {calls_done}/{len(units)} batches.")
+                    try:
+                        sidx, pids = next(it)
+                    except StopIteration:
+                        continue
+                    tg.create_task(worker(sidx, pids))
+                    in_flight += 1
+        finally:
+            pbar.close()
+            if since_checkpoint > 0:
                 self._save_scoring_ckpt()
-
-            result = await self._score_single_policy(
-                policy, self._X, existing=existing, on_progress=on_progress
-            )
-            self._policy_memory.at[policy_idx, "predictions"] = result  # type: ignore
-            self._save_scoring_ckpt()
-            if (i + 1) % self.p_predict_update_interval == 0:
-                logger.info(f"Scored {i + 1}/{total} policies.")
 
         logger.info("Scoring complete.")
 
@@ -980,52 +1152,74 @@ class PolicyInduction:
         ]
 
         results = np.zeros(len(self._feature_order_), dtype=float)
+        missing_positions: List[int] = []
         done_q: asyncio.Queue[None] = asyncio.Queue()
 
-        async def worker(pos: int, policy_text: str) -> None:
+        # Same batching as fit-time scoring, via the same primitive, so the
+        # features fed to the LR here match the ones it was trained on.
+        bs = self.policy_batch_size
+        units: List[List[Tuple[int, str]]] = [
+            tasks_to_run[i : i + bs] for i in range(0, len(tasks_to_run), bs)
+        ]
+
+        async def worker(chunk: List[Tuple[int, str]]) -> None:
             try:
-                query = (
-                    f"Task description:\n{self._task_description}\n\n"
-                    f"Policy:\n{policy_text}\n\n"
-                    f"Sample:\n{sample}\n\n"
-                )
-                async with self._llm_semaphore:
-                    response = await llm.respond(
-                        query=query,
-                        llm_priority=self.predict_llmc,
-                        instructions=POLICY_PREDICT_INSTRUCTIONS,
-                        response_format=Answer,
-                        temperature=self.predict_temperature,
-                    )
-                await token_counter.append(
-                    provider=response.provider_model.provider,
-                    model=response.provider_model.model,
-                    value=response.total_tokens,
+                answers = await self._score_policy_batch(
+                    sample_str=sample,
+                    policies=[(str(pos), pt) for pos, pt in chunk],
+                    token_counter=token_counter,
                     caller="PolicyInduction.predict_single",
                 )
-                if response.response is None:
-                    raise LLMError("No response from LLM")
-                txt = str(response.response.answer).strip().upper().strip('".,;:')
-                results[pos] = 1.0 if txt == "YES" or "YES" in txt else 0.0
+                for pos, _pt in chunk:
+                    ans = answers.get(str(pos))
+                    if ans is None:
+                        missing_positions.append(pos)
+                    else:
+                        results[pos] = 1.0 if ans == "YES" else 0.0
             except Exception:
                 logger.warning("Predict worker error", exc_info=True)
-                results[pos] = 0.0
+                missing_positions.extend(pos for pos, _ in chunk)
             finally:
                 done_q.put_nowait(None)
 
+        it = iter(units)
         in_flight = 0
         async with asyncio.TaskGroup() as tg:
-            for _ in range(min(self.llm_semaphore_limit, len(tasks_to_run))):
-                pos, pt = tasks_to_run.pop(0)
-                tg.create_task(worker(pos, pt))
+            for _ in range(self.llm_semaphore_limit):
+                try:
+                    chunk = next(it)
+                except StopIteration:
+                    break
+                tg.create_task(worker(chunk))
                 in_flight += 1
             while in_flight > 0:
                 await done_q.get()
                 in_flight -= 1
-                if tasks_to_run:
-                    pos, pt = tasks_to_run.pop(0)
-                    tg.create_task(worker(pos, pt))
-                    in_flight += 1
+                try:
+                    chunk = next(it)
+                except StopIteration:
+                    continue
+                tg.create_task(worker(chunk))
+                in_flight += 1
+
+        if missing_positions:
+            if len(missing_positions) == len(tasks_to_run):
+                # Every policy failed, so `results` would be all zeros — a
+                # vector the LR would happily classify despite resting on no
+                # evidence at all. Refuse to produce a record; predict() skips
+                # the sample and leaves it out of the checkpoint so a later
+                # run retries it.
+                raise LLMError(
+                    f"Sample {sample_index}: no policy answers obtained "
+                    f"({len(tasks_to_run)} policies queried)."
+                )
+            logger.warning(
+                "Sample %s: %d/%d policy answers missing after re-query; "
+                "treating as NO.",
+                sample_index,
+                len(missing_positions),
+                len(tasks_to_run),
+            )
 
         return sample_index, results, self._lr_predict(results)
 
@@ -1076,6 +1270,12 @@ class PolicyInduction:
         matching in-progress checkpoint found there — same unconditional,
         single-file design as fit(). The checkpoint is deleted once every
         sample has been predicted.
+
+        May yield fewer records than len(samples): a sample for which no
+        policy answer could be obtained at all is skipped rather than given a
+        prediction built from an all-zero feature vector. Skipped samples are
+        left out of the checkpoint, which is retained so a later run retries
+        them.
 
         Args:
             samples: DataFrame of samples to classify.
@@ -1129,11 +1329,19 @@ class PolicyInduction:
         queue: asyncio.Queue = asyncio.Queue()
         sem = asyncio.Semaphore(self.llm_semaphore_limit)
 
+        had_failures = False
+
         async def worker(idx: Any, sample_str: str) -> None:
+            nonlocal had_failures
             await sem.acquire()
             try:
                 rec = await self._predict_single(idx, sample_str, token_counter)
                 await queue.put(rec)
+            except Exception:
+                had_failures = True
+                logger.warning(
+                    "Predict failed for sample %s; skipping.", idx, exc_info=True
+                )
             finally:
                 await queue.put("DONE")
                 sem.release()
@@ -1177,9 +1385,10 @@ class PolicyInduction:
             for t in tasks:
                 if not t.done():
                     t.cancel()
-            if success:
+            if success and not had_failures:
                 self._del_ckpt(self._PREDICT_CKPT_NAME)
-            elif since_checkpoint > 0:
+            elif since_checkpoint > 0 or had_failures:
+                # Keep the checkpoint so skipped samples are retried next run.
                 save_ckpt()
 
     # ── Persistence ─────────────────────────────────────────────────────────────
@@ -1327,7 +1536,7 @@ class PolicyInduction:
             else None
         )
         manifest = {
-            "version": 2,
+            "version": 3,
             "name": self.name,
             "gen_llmc": [
                 lc if isinstance(lc, dict) else lc.model_dump() for lc in self.gen_llmc
@@ -1342,6 +1551,7 @@ class PolicyInduction:
             "max_policy_length": self.max_policy_length,
             "class_ratio": list(self.class_ratio),
             "max_samples_as_context": self.max_samples_as_context,
+            "policy_batch_size": self.policy_batch_size,
             "p_predict_update_interval": self.p_predict_update_interval,
             "random_state": self.random_state,
             "task_description": self._task_description,
@@ -1389,6 +1599,9 @@ class PolicyInduction:
             max_policy_length=m["max_policy_length"],
             class_ratio=tuple(m["class_ratio"]),
             max_samples_as_context=m["max_samples_as_context"],
+            # `or`, not get(key, 10): save() writes this key unconditionally,
+            # so a present-but-None value would defeat a two-arg get default.
+            policy_batch_size=int(m.get("policy_batch_size") or 10),
             p_predict_update_interval=m["p_predict_update_interval"],
             random_state=m["random_state"],
             save_path=str(base),

--- a/think_reason_learn/policy_induction/_policy_induction.py
+++ b/think_reason_learn/policy_induction/_policy_induction.py
@@ -137,6 +137,10 @@ class PolicyInduction:
             fill its share, so imbalanced datasets won't have every
             majority-class row shown during generation.
         max_samples_as_context: Samples per generation batch (max 100).
+        max_gen_batches: Cap on the number of generation batches. Generation
+            stops at this many batches even if both classes still have rows
+            left. None (default) keeps the original behaviour: stop only once
+            either class runs out.
         policy_batch_size: Number of policies judged per LLM call (1-50). One
             call carries one sample and up to this many policies, returning
             one answer per policy. 1 restores the original one-call-per-
@@ -164,6 +168,7 @@ class PolicyInduction:
         max_policy_length: int = 20,
         class_ratio: Tuple[float, float] = (1.0, 1.0),
         max_samples_as_context: int = 10,
+        max_gen_batches: int | None = 7,
         policy_batch_size: int = 10,
         p_predict_update_interval: int = 10,
         save_path: str | PathLike[str] | None = None,
@@ -176,6 +181,7 @@ class PolicyInduction:
             max_policy_length=max_policy_length,
             class_ratio=class_ratio,
             llm_semaphore_limit=llm_semaphore_limit,
+            max_gen_batches=max_gen_batches,
             policy_batch_size=policy_batch_size,
             p_predict_update_interval=p_predict_update_interval,
             save_path=save_path,
@@ -193,6 +199,7 @@ class PolicyInduction:
         self.max_policy_length = max_policy_length
         self.random_state = random_state
         self.max_samples_as_context = max_samples_as_context
+        self.max_gen_batches = max_gen_batches
         self.policy_batch_size = policy_batch_size
         self.p_predict_update_interval = p_predict_update_interval
         self.confirm_requests = confirm_requests
@@ -270,6 +277,12 @@ class PolicyInduction:
             raise ValueError("class_ratio must be two positive floats")
         if kw["llm_semaphore_limit"] <= 0:
             raise ValueError("llm_semaphore_limit must be > 0")
+        mgb = kw["max_gen_batches"]
+        if not (
+            mgb is None
+            or (isinstance(mgb, int) and not isinstance(mgb, bool) and mgb > 0)
+        ):
+            raise ValueError("max_gen_batches must be None or a positive integer")
         # Upper bound guards against output-token truncation: the LLM layer has
         # no retry, and a truncated structured response is a hard parse failure.
         pbs = kw["policy_batch_size"]
@@ -475,7 +488,11 @@ class PolicyInduction:
         ckpt = self._read_ckpt(self._FIT_CKPT_NAME) or {}
         batches_done: int = ckpt.get("batches_done", 0)
         total_batches = sum(
-            1 for _ in self._sample(self.max_samples_as_context, seed=self.random_state)
+            1
+            for _ in itertools.islice(
+                self._sample(self.max_samples_as_context, seed=self.random_state),
+                self.max_gen_batches,
+            )
         )
         gen_remaining = max(total_batches - batches_done, 0)
 
@@ -591,11 +608,13 @@ class PolicyInduction:
         # Skip already-done batches via islice (still advances _sample()'s
         # internal RNG state correctly) instead of iterating through them
         # inside the progress bar, so a resumed run starts the bar at
-        # batches_done instead of flashing through 0..batches_done.
+        # batches_done instead of flashing through 0..batches_done. The stop
+        # bound applies max_gen_batches on top of the class-exhaustion stop
+        # _sample() already does on its own; None means no extra cap.
         remaining_batches = itertools.islice(
             self._sample(self.max_samples_as_context, seed=self.random_state),
             batches_done,
-            None,
+            self.max_gen_batches,
         )
         for batch_idx, sample_df in enumerate(
             tqdm(
@@ -1551,6 +1570,7 @@ class PolicyInduction:
             "max_policy_length": self.max_policy_length,
             "class_ratio": list(self.class_ratio),
             "max_samples_as_context": self.max_samples_as_context,
+            "max_gen_batches": self.max_gen_batches,
             "policy_batch_size": self.policy_batch_size,
             "p_predict_update_interval": self.p_predict_update_interval,
             "random_state": self.random_state,
@@ -1599,6 +1619,9 @@ class PolicyInduction:
             max_policy_length=m["max_policy_length"],
             class_ratio=tuple(m["class_ratio"]),
             max_samples_as_context=m["max_samples_as_context"],
+            # Default is None either way, so a missing key (old saves) and an
+            # explicit null both resolve correctly with a plain .get().
+            max_gen_batches=m.get("max_gen_batches"),
             # `or`, not get(key, 10): save() writes this key unconditionally,
             # so a present-but-None value would defeat a two-arg get default.
             policy_batch_size=int(m.get("policy_batch_size") or 10),

--- a/think_reason_learn/policy_induction/_prompts.py
+++ b/think_reason_learn/policy_induction/_prompts.py
@@ -58,3 +58,32 @@ Requirements:
 Output format:
 Return ONLY ONE WORD: YES / NO.
 """
+
+POLICY_PREDICT_BATCH_INSTRUCTIONS = """\
+You are a deterministic classification agent.
+
+Given:
+- A task description
+- A numbered list of policies, each labelled with a unique integer id
+- A single sample (text)
+
+Objective:
+For EVERY policy in the list, classify the sample as either "YES" or "NO"
+according to that policy and the task description.
+
+Requirements:
+- Judge each policy INDEPENDENTLY. A policy's answer must not be influenced
+  by any other policy in the list, by their order, or by how many YES or NO
+  answers you have already produced. Treat each one as if it were the only
+  policy you had been given.
+- Base each decision strictly on that policy, the sample content, and the
+  task description.
+- Be deterministic: the same input must always yield the same output.
+- Return exactly one answer for every policy id — no more, no fewer.
+- Echo each policy's id exactly as it appears in the list. Do not renumber
+  or invent ids.
+- Do not explain your reasoning.
+
+Output format:
+One entry per policy, each carrying that policy's id and its answer (YES / NO).
+"""


### PR DESCRIPTION
## Summary
Adds batched LLM calls to `PolicyInduction`, cutting request volume in fit-time scoring and `predict()`.

- **`policy_batch_size` (default 10)** — one LLM call judges a sample against up to N policies instead of one. Batching the *policy* axis is what saves tokens: sample text is sent once per call instead of once per policy.
- **`max_gen_batches` (default 7)** — caps generation rounds instead of running until a class is exhausted. `None` disables.

One shared primitive drives both scoring and predict, so features are drawn identically at fit and inference time. `policy_batch_size=1` reproduces the original behaviour exactly.

Since a failed batch now costs N answers instead of 1: alignment uses id-tagged pydantic schemas rather than positional trust, missing answers are re-queried individually, and `predict()` skips a sample rather than emitting an all-zero feature vector.

**Behaviour change:** both defaults change `fit()` out of the box (generation caps at 7 batches; scoring batches 10 policies/call). Manifest bumped to version 3.

## Type of change
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] test
- [ ] chore

## Checklist
- [x] Tests added/updated — 39 tests; this file previously had none (fully commented out). Adds `tests/fake_policy_llm.py` for offline testing.
- [x] Lint and type-check pass — clean on `policy_induction`; see CI note.
- [x] Docs updated — docstrings cover both new params.

### CI note
Two failures are **pre-existing on `main`**, verified by reproducing them there: `pyright` on `rrf/_rrf.py:1573` (hook runs repo-wide), and `test_xai_llm.py` (test-ordering pollution, passes in isolation). Suite here: 289 passed, 1 failed. Happy to split the `rrf` fix into its own PR if you want green CI first.

## Related issues
N/A
